### PR TITLE
Fix failing iPad UI test for opening a website

### DIFF
--- a/LockboxXCUITests/LockBoxScreenGraph.swift
+++ b/LockboxXCUITests/LockBoxScreenGraph.swift
@@ -148,7 +148,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
 
         screenState.gesture(forAction: Action.OpenWebsite) { userState in
-            app.cells["webAddressItemDetail"].press(forDuration: 1)
+            app.buttons["open.button"].tap()
         }
 
     }


### PR DESCRIPTION
Fixes #963 

The `testCheckEntryDetailsView`is failing on [latest master](https://dashboard.buddybuild.com/apps/5a0ddb736e19370001034f85/build/5cd5fd544d5116000109c81c/test/ec5957a7-ce6c-47d7-9b06-5677d909757f/43a1da8e-a2d2-43dd-b340-cf4b793fdd0f) on BB. 
This PR tries to fix that issue by changing the element used to open a website from the entry view.