### PR TITLE
log errors outside of debug, push errored state, handle fxa errors

### DIFF
--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -161,7 +161,7 @@
 		7D4396542135B0C200B96FA9 /* CredentialProviderAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4396522135B0C200B96FA9 /* CredentialProviderAction.swift */; };
 		7D4396552135C2FF00B96FA9 /* SpinnerAlert.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7D1D2F0720AA39700011BFC8 /* SpinnerAlert.xib */; };
 		7D4396572135D79800B96FA9 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D4396562135D79700B96FA9 /* Sentry.framework */; };
-		7D4396612135D8BD00B96FA9 /* SentryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4396602135D8BC00B96FA9 /* SentryManager.swift */; };
+		7D4396612135D8BD00B96FA9 /* SentryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4396602135D8BC00B96FA9 /* SentryStore.swift */; };
 		7D440889201786E4001873F6 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D440888201786E4001873F6 /* WelcomeView.swift */; };
 		7D44088B201786F1001873F6 /* WelcomePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D44088A201786F1001873F6 /* WelcomePresenter.swift */; };
 		7D44088E20178713001873F6 /* WelcomePresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D44088C20178713001873F6 /* WelcomePresenterSpec.swift */; };
@@ -228,6 +228,8 @@
 		7DBDBBC922726E1E00A4EF14 /* DataStoreSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DBDBBC722726E1E00A4EF14 /* DataStoreSupport.swift */; };
 		7DC3899C20B600820057929D /* ItemDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DC3899E20B600820057929D /* ItemDetail.storyboard */; };
 		7DC75D79206AD01C007CDDBB /* AccountSetting.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DC75D7B206AD01C007CDDBB /* AccountSetting.storyboard */; };
+		7DD2BED2228F120600E283B9 /* SentryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD2BED1228F120600E283B9 /* SentryAction.swift */; };
+		7DD2BED3228F148700E283B9 /* SentryAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD2BED1228F120600E283B9 /* SentryAction.swift */; };
 		7DDEAA622124B24E00A7D521 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54CDEA56C47263160AD0E /* Dispatcher.swift */; };
 		7DDEAA652124B27600A7D521 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D9D64921F9F8EE300279C39 /* RxCocoa.framework */; };
 		7DDEAA662124B27900A7D521 /* RxDataSources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D320B3420360F9000891F73 /* RxDataSources.framework */; };
@@ -501,7 +503,7 @@
 		7D43964F2135AFBD00B96FA9 /* CredentialProviderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialProviderStore.swift; sourceTree = "<group>"; };
 		7D4396522135B0C200B96FA9 /* CredentialProviderAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialProviderAction.swift; sourceTree = "<group>"; };
 		7D4396562135D79700B96FA9 /* Sentry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sentry.framework; path = Carthage/Build/iOS/Sentry.framework; sourceTree = "<group>"; };
-		7D4396602135D8BC00B96FA9 /* SentryManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SentryManager.swift; path = "lockbox-ios/Common/Helpers/SentryManager.swift"; sourceTree = SOURCE_ROOT; };
+		7D4396602135D8BC00B96FA9 /* SentryStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SentryStore.swift; path = "lockbox-ios/Store/SentryStore.swift"; sourceTree = SOURCE_ROOT; };
 		7D440888201786E4001873F6 /* WelcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WelcomeView.swift; path = "lockbox-ios/View/WelcomeView.swift"; sourceTree = SOURCE_ROOT; };
 		7D44088A201786F1001873F6 /* WelcomePresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WelcomePresenter.swift; path = "lockbox-ios/Presenter/WelcomePresenter.swift"; sourceTree = SOURCE_ROOT; };
 		7D44088C20178713001873F6 /* WelcomePresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomePresenterSpec.swift; sourceTree = "<group>"; };
@@ -546,6 +548,7 @@
 		7DBDBBC722726E1E00A4EF14 /* DataStoreSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreSupport.swift; sourceTree = "<group>"; };
 		7DC3899D20B600820057929D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/ItemDetail.storyboard; sourceTree = "<group>"; };
 		7DC75D7A206AD01C007CDDBB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/AccountSetting.storyboard; sourceTree = "<group>"; };
+		7DD2BED1228F120600E283B9 /* SentryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAction.swift; sourceTree = "<group>"; };
 		7DDEAA702124CEB100A7D521 /* DataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStore.swift; sourceTree = "<group>"; };
 		7DE5896D2125D20C005CFF47 /* CredentialAccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialAccountStore.swift; sourceTree = "<group>"; };
 		7DEA1C4120362E09008AD7C4 /* Differentiator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Differentiator.framework; path = Carthage/Build/iOS/Differentiator.framework; sourceTree = "<group>"; };
@@ -727,7 +730,6 @@
 		7AA54273E00B828CAEA30FA9 /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				7D43965F2135D8B000B96FA9 /* Helpers */,
 				7AA549BD9AE6A6DD82FDA434 /* AppDelegate.swift */,
 				7AA54C03E372B15AC9309717 /* Extensions */,
 				7AA547FECD9BACFBEE60F8B8 /* Resources */,
@@ -738,6 +740,7 @@
 		7AA5453C4865C63179179FE2 /* Store */ = {
 			isa = PBXGroup;
 			children = (
+				7D4396602135D8BC00B96FA9 /* SentryStore.swift */,
 				7AA544CADF713D6B1E330659 /* UserDefaultStore.swift */,
 				7AA54C369D0BF64704C8D5FB /* RouteStore.swift */,
 				7AA54146E0C9269A0CE8D53A /* AccountStore.swift */,
@@ -788,6 +791,7 @@
 				7AA54B41C60F04FA585E5B8F /* ItemDetailAction.swift */,
 				7AA54E38ACC2FDBBF700D5E1 /* RouteAction.swift */,
 				7D078EEA2124DCE100D10D1B /* SettingAction.swift */,
+				7DD2BED1228F120600E283B9 /* SentryAction.swift */,
 			);
 			path = Action;
 			sourceTree = "<group>";
@@ -1083,14 +1087,6 @@
 				7D2712B8224D70E900E6C4CA /* SyncCredential.swift */,
 			);
 			path = Model;
-			sourceTree = "<group>";
-		};
-		7D43965F2135D8B000B96FA9 /* Helpers */ = {
-			isa = PBXGroup;
-			children = (
-				7D4396602135D8BC00B96FA9 /* SentryManager.swift */,
-			);
-			path = Helpers;
 			sourceTree = "<group>";
 		};
 		7D522E952033473F00295FF8 /* Strings */ = {
@@ -1651,7 +1647,7 @@
 				7AA547EF949CA76FC018402A /* ItemListCell.swift in Sources */,
 				7AA54A743320656025DC5B3E /* ItemDetailCell.swift in Sources */,
 				7DB9DEA12140CC0300239D31 /* ItemListView.swift in Sources */,
-				7D4396612135D8BD00B96FA9 /* SentryManager.swift in Sources */,
+				7D4396612135D8BD00B96FA9 /* SentryStore.swift in Sources */,
 				D878360F207ABDF100C19BC7 /* StaticURLWebView.swift in Sources */,
 				D819A4BC21BAFA6F004EE6F3 /* File.swift in Sources */,
 				08454B9A21486BCF00328040 /* TelemetryStore.swift in Sources */,
@@ -1668,6 +1664,7 @@
 				D819A4B921BAF988004EE6F3 /* LoginRecord+.swift in Sources */,
 				D85CB82321DED0E100E19118 /* ViewFactory.swift in Sources */,
 				3931871E214C12C5003C9E4A /* AppearanceHelper.swift in Sources */,
+				7DD2BED2228F120600E283B9 /* SentryAction.swift in Sources */,
 				7D1D2F0420AA394A0011BFC8 /* SpinnerAlert.swift in Sources */,
 				7AA54E0EAF2761904796DB90 /* ItemListDisplayStore.swift in Sources */,
 				7AA548100774B367341D450F /* ItemListDisplayAction.swift in Sources */,
@@ -1711,6 +1708,7 @@
 				08454B9B21486BCF00328040 /* TelemetryStore.swift in Sources */,
 				7D9722DB21348C2F0071D82B /* CredentialWelcomePresenter.swift in Sources */,
 				D8C20D6C22013A0D001B4A27 /* SizeClassStore.swift in Sources */,
+				7DD2BED3228F148700E283B9 /* SentryAction.swift in Sources */,
 				7D9722C8213464020071D82B /* UIViewController+.swift in Sources */,
 				7D9722E021349B9F0071D82B /* CredentialStatusAction.swift in Sources */,
 				7D078EF42124E24100D10D1B /* BaseConstants.swift in Sources */,

--- a/Shared/Store/BaseAccountStore.swift
+++ b/Shared/Store/BaseAccountStore.swift
@@ -10,6 +10,7 @@ import SwiftKeychainWrapper
 import WebKit
 
 class BaseAccountStore {
+    internal let dispatcher: Dispatcher
     internal var keychainWrapper: KeychainWrapper
     internal let networkStore: NetworkStore
 
@@ -31,8 +32,10 @@ class BaseAccountStore {
         return self.keychainWrapper.string(forKey: key)
     }
 
-    init(keychainWrapper: KeychainWrapper = KeychainWrapper.sharedAppContainerKeychain,
+    init(dispatcher: Dispatcher = .shared,
+         keychainWrapper: KeychainWrapper = KeychainWrapper.sharedAppContainerKeychain,
          networkStore: NetworkStore = NetworkStore.shared) {
+        self.dispatcher = dispatcher
         self.keychainWrapper = keychainWrapper
         self.networkStore = networkStore
 
@@ -55,6 +58,13 @@ class BaseAccountStore {
 
         fxa.getAccessToken(scope: Constant.fxa.oldSyncScope) { [weak self] (accessToken, err) in
             if let error = err {
+                let sentryAction = SentryAction(
+                    title: "FxAException",
+                    error: error,
+                    function: "\(#function)",
+                    line: "\(#line)"
+                )
+                self?.dispatcher.dispatch(action: sentryAction)
                 NSLog("Unexpected error getting access token: \(error.localizedDescription)")
                 self?._syncCredentials.onNext(nil)
             }

--- a/Shared/Store/BaseAccountStore.swift
+++ b/Shared/Store/BaseAccountStore.swift
@@ -54,6 +54,11 @@ class BaseAccountStore {
         }
 
         fxa.getAccessToken(scope: Constant.fxa.oldSyncScope) { [weak self] (accessToken, err) in
+            if let error = err {
+                NSLog("Unexpected error getting access token: \(error.localizedDescription)")
+                self?._syncCredentials.onNext(nil)
+            }
+
             guard let key = accessToken?.key,
                 let token = accessToken?.token
                 else { return }

--- a/Shared/Store/BaseDataStore.swift
+++ b/Shared/Store/BaseDataStore.swift
@@ -238,8 +238,10 @@ extension BaseDataStore {
         queue.async {
             do {
                 try self.loginsStorage?.sync(unlockInfo: syncInfo)
+            } catch let error as LoginStoreError {
+                self.storageStateSubject.onNext(.Errored(cause: error))
             } catch let error {
-                print("Sync15 Sync Error: \(error)")
+                NSLog("Unknown error syncing: \(error)")
             }
             self.syncSubject.onNext(SyncState.Synced)
         }
@@ -252,8 +254,10 @@ extension BaseDataStore {
             do {
                 let loginRecords = try loginsStorage.list()
                 self.listSubject.accept(loginRecords)
+            } catch let error as LoginStoreError {
+                self.storageStateSubject.onNext(.Errored(cause: error))
             } catch let error {
-                print("Sync15 list update error: \(error)")
+                NSLog("Unknown error updating list: \(error)")
             }
         }
     }
@@ -302,8 +306,8 @@ extension BaseDataStore {
         guard let loginsStorage = self.loginsStorage else { return }
 
         queue.async {
-            loginsStorage.ensureLocked()
             self.storageStateSubject.onNext(.Locked)
+            loginsStorage.ensureLocked()
         }
     }
 
@@ -314,8 +318,10 @@ extension BaseDataStore {
         do {
             try loginsStorage.ensureUnlocked(withEncryptionKey: loginsKey)
             self.storageStateSubject.onNext(.Unlocked)
+        } catch let error as LoginStoreError {
+            self.storageStateSubject.onNext(.Errored(cause: error))
         } catch let error {
-            print("LoginsError: \(error)")
+            NSLog("Unknown error unlocking: \(error)")
         }
     }
 
@@ -355,8 +361,10 @@ extension BaseDataStore {
                 self.storageStateSubject.onNext(.Unprepared)
                 try loginsStorage.ensureUnlocked(withEncryptionKey: loginsKey)
                 try loginsStorage.wipeLocal()
+            } catch let error as LoginStoreError {
+                self.storageStateSubject.onNext(.Errored(cause: error))
             } catch let error {
-                print("Sync15 wipe error: \(error.localizedDescription)")
+                NSLog("Unknown error wiping database: \(error.localizedDescription)")
             }
         }
     }

--- a/lockbox-ios/Action/SentryAction.swift
+++ b/lockbox-ios/Action/SentryAction.swift
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+struct SentryAction: Action {
+    let title: String
+    let error: Error
+    let function: String
+    let line: String
+}

--- a/lockbox-ios/Presenter/RootPresenter.swift
+++ b/lockbox-ios/Presenter/RootPresenter.swift
@@ -53,7 +53,7 @@ class RootPresenter {
     fileprivate let lifecycleStore: LifecycleStore
     fileprivate let telemetryActionHandler: TelemetryActionHandler
     fileprivate let biometryManager: BiometryManager
-    fileprivate let sentryManager: Sentry
+    fileprivate let sentryManager: SentryStore
     fileprivate let adjustManager: AdjustManager
     fileprivate let viewFactory: ViewFactory
     fileprivate let sizeClassStore: SizeClassStore
@@ -73,7 +73,7 @@ class RootPresenter {
          lifecycleStore: LifecycleStore = .shared,
          telemetryActionHandler: TelemetryActionHandler = TelemetryActionHandler(accountStore: AccountStore.shared),
          biometryManager: BiometryManager = BiometryManager(),
-         sentryManager: Sentry = Sentry.shared,
+         sentryManager: SentryStore = SentryStore.shared,
          adjustManager: AdjustManager = AdjustManager.shared,
          viewFactory: ViewFactory = ViewFactory.shared,
          sizeClassStore: SizeClassStore = SizeClassStore.shared,

--- a/lockbox-ios/Presenter/RootPresenter.swift
+++ b/lockbox-ios/Presenter/RootPresenter.swift
@@ -126,13 +126,6 @@ class RootPresenter {
             })
             .disposed(by: self.disposeBag)
 
-        self.dataStore.storageState
-            .filter { $0 == LoginStoreState.Unprepared }
-            .subscribe(onNext: { _ in
-                self.dispatcher.dispatch(action: LoginRouteAction.welcome)
-            })
-            .disposed(by: self.disposeBag)
-
         self.lifecycleStore.lifecycleEvents
             .subscribe(onNext: { lifecycleAction in
                 switch lifecycleAction {
@@ -146,7 +139,6 @@ class RootPresenter {
             })
             .disposed(by: self.disposeBag)
 
-        self.dispatcher.dispatch(action: OnboardingStatusAction(onboardingInProgress: false))
         self.startTelemetry()
         self.startAdjust()
         self.startSentry()

--- a/lockbox-ios/Store/AccountStore.swift
+++ b/lockbox-ios/Store/AccountStore.swift
@@ -35,7 +35,6 @@ enum LocalUserDefaultKey: String {
 class AccountStore: BaseAccountStore {
     static let shared = AccountStore()
 
-    private let dispatcher: Dispatcher
     private let urlCache: URLCache
     private let webData: WKWebsiteDataStore
     private let disposeBag = DisposeBag()
@@ -57,11 +56,10 @@ class AccountStore: BaseAccountStore {
          urlCache: URLCache = URLCache.shared,
          webData: WKWebsiteDataStore = WKWebsiteDataStore.default()
         ) {
-        self.dispatcher = dispatcher
         self.urlCache = urlCache
         self.webData = webData
 
-        super.init(keychainWrapper: keychainWrapper, networkStore: networkStore)
+        super.init(dispatcher: dispatcher, keychainWrapper: keychainWrapper, networkStore: networkStore)
     }
 
     override func initialized() {

--- a/lockbox-ios/Store/RouteStore.swift
+++ b/lockbox-ios/Store/RouteStore.swift
@@ -11,7 +11,7 @@ class RouteStore {
 
     fileprivate let disposeBag = DisposeBag()
     fileprivate var routeState = ReplaySubject<RouteAction>.create(bufferSize: 1)
-    fileprivate var onboardingState = ReplaySubject<Bool>.create(bufferSize: 1)
+    fileprivate var onboardingState = BehaviorRelay<Bool>(value: false)
 
     public var onRoute: Observable<RouteAction> {
         return self.routeState.asObservable()

--- a/lockbox-iosTests/RootPresenterSpec.swift
+++ b/lockbox-iosTests/RootPresenterSpec.swift
@@ -202,7 +202,7 @@ class RootPresenterSpec: QuickSpec {
         }
     }
 
-    class FakeSentryManager: Lockbox.Sentry {
+    class FakeSentryManager: Lockbox.SentryStore {
         var setupCalled: Bool = false
 
         override func setup(sendUsageData: Bool) {


### PR DESCRIPTION
Fixes #950

## Testing and Review Notes

It's hard to debug exactly how users are ending up in this state, but given that all problems are arising from upgrading, I suspect that there's an issue with getting the access token from a previously stored FxA instance, which we don't handle very gracefully. I've also made some improvements to how we handle errors in the DataStore to catch future areas of weirdness there.

I will note that my solution results in the user needing to log in again; hopefully having a fresh set of credentials will prevent this issue from happening in the future, and while it's annoying, it seems better than needing to fully delete + reinstall the app.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
