### PR TITLE
autolock respected and reset properly in autofill contexts

### DIFF
--- a/CredentialProvider/Action/CredentialStatusAction.swift
+++ b/CredentialProvider/Action/CredentialStatusAction.swift
@@ -4,32 +4,38 @@
 
 import Foundation
 import MozillaAppServices
+import AuthenticationServices
 
+@available(iOS 12, *)
 enum CredentialStatusAction: Action {
-    case extensionConfigured, userCanceled, loginSelected(login: LoginRecord, relock: Bool)
+    case extensionConfigured,
+         cancelled(error: ASExtensionError.Code),
+         loginSelected(login: LoginRecord)
 }
 
+@available(iOS 12, *)
 extension CredentialStatusAction: Equatable {
     static func ==(lhs: CredentialStatusAction, rhs: CredentialStatusAction) -> Bool {
         switch (lhs, rhs) {
         case (.extensionConfigured, .extensionConfigured):
             return true
-        case (.userCanceled, .userCanceled):
-            return true
-        case (.loginSelected(let lhLogin, let lhRelock), .loginSelected(let rhLogin, let rhRelock)):
-            return lhLogin == rhLogin && lhRelock == rhRelock
+        case (.cancelled(let lhError), .cancelled(let rhError)):
+            return lhError == rhError
+        case (.loginSelected(let lhLogin), .loginSelected(let rhLogin)):
+            return lhLogin == rhLogin
         default:
             return false
         }
     }
 }
 
+@available(iOS 12, *)
 extension CredentialStatusAction: TelemetryAction {
     var eventMethod: TelemetryEventMethod {
         switch self {
         case .extensionConfigured:
             return .settingChanged
-        case .userCanceled:
+        case .cancelled:
             return .canceled
         case .loginSelected:
             return .login_selected

--- a/CredentialProvider/Presenter/CredentialItemListPresenter.swift
+++ b/CredentialProvider/Presenter/CredentialItemListPresenter.swift
@@ -31,9 +31,9 @@ class ItemListPresenter: BaseItemListPresenter {
             target.dataStore.get(id)
                 .map { login -> CredentialStatusAction in
                     if let login = login {
-                        return CredentialStatusAction.loginSelected(login: login, relock: false)
+                        return CredentialStatusAction.loginSelected(login: login)
                     } else {
-                        return CredentialStatusAction.userCanceled
+                        return CredentialStatusAction.cancelled(error: .userCanceled)
                     }
                 }
                 .subscribe(onNext: { target.dispatcher.dispatch(action: $0) })
@@ -45,7 +45,7 @@ class ItemListPresenter: BaseItemListPresenter {
 
     lazy var cancelButtonObserver: AnyObserver<Void> = {
         return Binder(self) { target, _ in
-            target.dispatcher.dispatch(action: CredentialStatusAction.userCanceled)
+            target.dispatcher.dispatch(action: CredentialStatusAction.cancelled(error: .userCanceled))
         }.asObserver()
     }()
 }

--- a/CredentialProvider/Presenter/CredentialItemListPresenter.swift
+++ b/CredentialProvider/Presenter/CredentialItemListPresenter.swift
@@ -24,9 +24,7 @@ class ItemListPresenter: BaseItemListPresenter {
                 return
             }
 
-            if let view = target.view {
-                view.dismissKeyboard()
-            }
+            target.view?.dismissKeyboard()
 
             target.dataStore.get(id)
                 .map { login -> CredentialStatusAction in

--- a/CredentialProvider/Presenter/CredentialProviderPresenter.swift
+++ b/CredentialProvider/Presenter/CredentialProviderPresenter.swift
@@ -101,7 +101,7 @@ class CredentialProviderPresenter {
                 .disposed(by: self.credentialProvisionBag)
     }
 
-    func interfaceToAuthentication(for credentialIdentity: ASPasswordCredentialIdentity) {
+    func prepareAuthentication(for credentialIdentity: ASPasswordCredentialIdentity) {
         self.dataStore.locked
                 .asDriver(onErrorJustReturn: true)
                 .drive(onNext: { [weak self] locked in

--- a/CredentialProvider/Presenter/CredentialWelcomePresenter.swift
+++ b/CredentialProvider/Presenter/CredentialWelcomePresenter.swift
@@ -96,7 +96,7 @@ class CredentialWelcomePresenter: BaseWelcomePresenter {
                         return
                     }
 
-                    self?.dispatcher.dispatch(action: CredentialStatusAction.userCanceled)
+                    self?.dispatcher.dispatch(action: CredentialStatusAction.cancelled(error: .userCanceled))
                 }
             )
             .disposed(by: self.authenticationBag)

--- a/CredentialProvider/Store/CredentialDataStore.swift
+++ b/CredentialProvider/Store/CredentialDataStore.swift
@@ -18,7 +18,12 @@ class DataStore: BaseDataStore {
     override func initialized() {
         self.dispatcher.register
                 .filterByType(class: CredentialStatusAction.self)
-                // when we get credential status actions, check the locked status
+                /* when we get credential status actions & are unlocked, store the next lock time
+                *
+                * why this works: credential status actions are sent at the conclusion of a user's interaction with the
+                * credential provider, and thus mirror the more generic "background" as relied on in the app lifecycle.
+                * from a user perception (and therefore functionality) standpoint, this begins the timer to the next
+                * lock time. */
                 .withLatestFrom(self.locked, resultSelector: { (_, locked) -> Void? in
                     // if we are already locked, do not store the next lock time
                     return locked ? nil : ()

--- a/CredentialProvider/Store/CredentialDataStore.swift
+++ b/CredentialProvider/Store/CredentialDataStore.swift
@@ -3,9 +3,30 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import RxSwift
 
 class DataStore: BaseDataStore {
+    private var dispatcher: Dispatcher
+    
     public static let shared = DataStore()
+    
+    init(dispatcher: Dispatcher = .shared) {
+        self.dispatcher = dispatcher
+        super.init()
+    }
 
-    override func initialized() { }
+    override func initialized() {
+        self.dispatcher.register
+                .filterByType(class: CredentialStatusAction.self)
+                // when we get credential status actions, check the locked status
+                .withLatestFrom(self.locked, resultSelector: { (_, locked) -> Void? in
+                    // if we are already locked, do not store the next lock time
+                    return locked ? nil : ()
+                })
+                .filterNil()
+                .subscribe(onNext: { [weak self] _ in
+                    self?.autoLockSupport.storeNextAutolockTime()
+                })
+                .disposed(by: self.disposeBag)
+    }
 }

--- a/CredentialProvider/View/CredentialProviderView.swift
+++ b/CredentialProvider/View/CredentialProviderView.swift
@@ -26,7 +26,7 @@ class CredentialProviderView: ASCredentialProviderViewController {
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return self.currentViewController?.preferredStatusBarStyle ?? .default
+        return self.currentViewController?.preferredStatusBarStyle ?? .lightContent
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/CredentialProvider/View/CredentialProviderView.swift
+++ b/CredentialProvider/View/CredentialProviderView.swift
@@ -49,7 +49,7 @@ class CredentialProviderView: ASCredentialProviderViewController {
     }
 
     override func prepareInterfaceToProvideCredential(for credentialIdentity: ASPasswordCredentialIdentity) {
-        self.presenter?.interfaceToAuthentication(for: credentialIdentity)
+        self.presenter?.prepareAuthentication(for: credentialIdentity)
     }
 
     override func provideCredentialWithoutUserInteraction(for credentialIdentity: ASPasswordCredentialIdentity) {

--- a/CredentialProvider/View/CredentialProviderView.swift
+++ b/CredentialProvider/View/CredentialProviderView.swift
@@ -48,6 +48,10 @@ class CredentialProviderView: ASCredentialProviderViewController {
         self.presenter?.credentialList(for: serviceIdentifiers)
     }
 
+    override func prepareInterfaceToProvideCredential(for credentialIdentity: ASPasswordCredentialIdentity) {
+        self.presenter?.interfaceToAuthentication(for: credentialIdentity)
+    }
+
     override func provideCredentialWithoutUserInteraction(for credentialIdentity: ASPasswordCredentialIdentity) {
         self.presenter?.credentialProvisionRequested(for: credentialIdentity)
     }

--- a/Shared/Store/BaseDataStore.swift
+++ b/Shared/Store/BaseDataStore.swift
@@ -76,7 +76,7 @@ class BaseDataStore {
 
     private let dispatcher: Dispatcher
     private let keychainWrapper: KeychainWrapper
-    private let autoLockSupport: AutoLockSupport
+    internal let autoLockSupport: AutoLockSupport
     private let dataStoreSupport: DataStoreSupport
     private let networkStore: NetworkStore
     private let lifecycleStore: LifecycleStore

--- a/lockbox-iosTests/CredentialStatusActionSpec.swift
+++ b/lockbox-iosTests/CredentialStatusActionSpec.swift
@@ -6,9 +6,11 @@ import Foundation
 import Quick
 import Nimble
 import MozillaAppServices
+import AuthenticationServices
 
 @testable import Lockbox
 
+@available(iOS 12.0, *)
 class CredentialStatusActionSpec: QuickSpec {
     override func spec() {
         describe("CredentialStatusAction") {
@@ -18,21 +20,19 @@ class CredentialStatusActionSpec: QuickSpec {
                 }
 
                 it("userCancelled is always equal") {
-                    expect(CredentialStatusAction.userCanceled).to(equal(CredentialStatusAction.userCanceled))
+                    expect(CredentialStatusAction.cancelled(error: .failed)).to(equal(CredentialStatusAction.cancelled(error: .failed)))
                 }
 
                 it("loginSelected is equalbased on login and relock values") {
                     let login1 = LoginRecord(fromJSONDict: ["id": "fasasdf", "hostname": "www.mozilla.com", "username": "dogs@dogs.com", "password": "meow"])
                     let login2 = LoginRecord(fromJSONDict: ["id": ";l;iiojlkljk", "hostname": "www.neopets.com", "username": "cats@cats.com", "password": "woof"])
 
-                    expect(CredentialStatusAction.loginSelected(login: login1, relock: true)).to(equal(CredentialStatusAction.loginSelected(login: login1, relock: true)))
-                    expect(CredentialStatusAction.loginSelected(login: login2, relock: true)).notTo(equal(CredentialStatusAction.loginSelected(login: login1, relock: true)))
-                    expect(CredentialStatusAction.loginSelected(login: login1, relock: true)).notTo(equal(CredentialStatusAction.loginSelected(login: login1, relock: false)))
-                    expect(CredentialStatusAction.loginSelected(login: login1, relock: true)).notTo(equal(CredentialStatusAction.loginSelected(login: login2, relock: false)))
+                    expect(CredentialStatusAction.loginSelected(login: login1)).to(equal(CredentialStatusAction.loginSelected(login: login1)))
+                    expect(CredentialStatusAction.loginSelected(login: login2)).notTo(equal(CredentialStatusAction.loginSelected(login: login1)))
                 }
 
                 it("different enum values are not equal") {
-                    expect(CredentialStatusAction.userCanceled).notTo(equal(CredentialStatusAction.extensionConfigured))
+                    expect(CredentialStatusAction.cancelled(error: .userCanceled)).notTo(equal(CredentialStatusAction.extensionConfigured))
                 }
             }
 


### PR DESCRIPTION
Fixes #982 
Fixes #976
Fixes #977 

## Testing and Review Notes
A few things to test here --
- autofill behaves as expected w.r.t. locked status when accessing credentials both via the QTB and the `Passwords` (pop-over list) interfaces, especially using them multiple times in succession as I've already noticed some interesting behavior with the CredentialProvider lifecycle. 
- autofill behaves as expected w.r.t. app authentication and lock status when configuring via settings.
- the way that the locked status of the app interacts with the credential provider. I've made the design choice that unlocking the credential provider will also unlock the app, but it should be locked again when launching after the designated amount of time. 

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
