### PR TITLE
fix issue where locking only happens once per app lifecycle

### DIFF
--- a/lockbox-iosTests/BaseDataStoreSpec.swift
+++ b/lockbox-iosTests/BaseDataStoreSpec.swift
@@ -291,6 +291,12 @@ class BaseDataStoreSpec: QuickSpec {
                     it("stores the next autolock time") {
                         expect(self.autoLockSupport.storeNextTimeCalled).to(beTrue())
                     }
+
+                    it("respects all future backgrounding actions") {
+                        self.autoLockSupport.clearInvocations()
+                        self.lifecycleStore.fakeCycle.onNext(.background)
+                        expect(self.autoLockSupport.storeNextTimeCalled).to(beTrue())
+                    }
                 }
 
                 describe("foregrounding actions") {


### PR DESCRIPTION
Fixes #1002 

## Testing and Review Notes

The bug description is very useful! This can also be reproduced by simply backgrounding, waiting for the app to lock once, and then trying to get it to lock in the background (NOT hard quitting) a second time.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
