### PR TITLE
Xcuitest snapshots work

### DIFF
--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -588,7 +588,6 @@
 		D0A64422B480D23AD53FEBB0 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Welcome.strings; sourceTree = "<group>"; };
 		D4AC7F5422980EEC00F75ACF /* SnapshotsXCUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotsXCUITests.swift; sourceTree = "<group>"; };
 		D50920EA22849F6600AC9580 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Welcome.strings; sourceTree = "<group>"; };
->>>>>>> initial changes
 		D50920F62284A18100AC9580 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ItemList.strings; sourceTree = "<group>"; };
 		D578C36E229F099D00E08CFF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/SetupAutofill.strings; sourceTree = "<group>"; };
 		D578C370229F09B600E08CFF /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/SetupAutofill.strings; sourceTree = "<group>"; };

--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -248,6 +248,8 @@
 		A1B04DCCB276B7FD665F1C96 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 135D40AD8E5C6CC264F33683 /* InfoPlist.strings */; };
 		D5BCA68D229DA4A800CF980C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D5BCA68B229DA4A800CF980C /* InfoPlist.strings */; };
 		D5BCA694229DA4E000CF980C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D5BCA692229DA4E000CF980C /* Localizable.strings */; };
+		D4AC7F5522980EEC00F75ACF /* SnapshotsXCUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4AC7F5422980EEC00F75ACF /* SnapshotsXCUITests.swift */; };
+		D59BC9902296EA5A009BA380 /* ItemList.strings in Resources */ = {isa = PBXBuildFile; fileRef = D59BC98E2296EA5A009BA380 /* ItemList.strings */; };
 		D5CC9BB8207D13660013CDEC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D5CC9BB7207D13660013CDEC /* LaunchScreen.storyboard */; };
 		D5E2930A207D59050039A0AC /* FiraSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D5E29308207D59030039A0AC /* FiraSans-Bold.ttf */; };
 		D5E2930B207D59050039A0AC /* FiraSans-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D5E29309207D59040039A0AC /* FiraSans-Italic.ttf */; };
@@ -565,6 +567,28 @@
 		80C24E078F9DA15264F2FA6F /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B0E84623AB91A6A141DD8403 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B3554B229BDD46895D14A661 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		7E904CA28EBB7443F9FE89AC /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/OnboardingConfirmation.strings; sourceTree = "<group>"; };
+		869D4637A6FA14D4794329EB /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/AccountSetting.strings; sourceTree = "<group>"; };
+		8EE9491EA5AC961DB7C1DC0F /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/AutofillOnboarding.strings; sourceTree = "<group>"; };
+		93F14299868926282C7BE457 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/SetupAutofill.strings; sourceTree = "<group>"; };
+		946A4B9DA79F205FE9FDF7E2 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingList.strings; sourceTree = "<group>"; };
+		9B1743909D27F5ADDCFB9070 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/CredentialWelcome.strings; sourceTree = "<group>"; };
+		A1E846EF8E1A41B85537A2B8 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/SettingList.strings; sourceTree = "<group>"; };
+		A39E4C8BAFEFCF421BB0CCA1 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/AccountSetting.strings; sourceTree = "<group>"; };
+		A5B1408487E377D6B6A45776 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/SettingList.strings; sourceTree = "<group>"; };
+		A6BC453496C837E6DC2EB35B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/OnboardingConfirmation.strings; sourceTree = "<group>"; };
+		B9274E1988CF7A31906531EB /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Welcome.strings; sourceTree = "<group>"; };
+		BBDA4B1E97EFFAB3638EE76B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/SettingList.strings; sourceTree = "<group>"; };
+		BCCD42ABBCCE5AD2EBAA24A8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ItemDetail.strings; sourceTree = "<group>"; };
+		BDA64A5480E65531D1760676 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/CredentialWelcome.strings; sourceTree = "<group>"; };
+		C3814B9B885EB543F5E69DE6 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Welcome.strings; sourceTree = "<group>"; };
+		C39D4CB984C16D5E2BD2C503 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Welcome.strings; sourceTree = "<group>"; };
+		C4E546209CFC87F20E83D345 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Welcome.strings; sourceTree = "<group>"; };
+		CE6E429AA6C7438EDF6473FA /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AccountSetting.strings; sourceTree = "<group>"; };
+		D0A64422B480D23AD53FEBB0 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Welcome.strings; sourceTree = "<group>"; };
+		D4AC7F5422980EEC00F75ACF /* SnapshotsXCUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotsXCUITests.swift; sourceTree = "<group>"; };
+		D50920EA22849F6600AC9580 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Welcome.strings; sourceTree = "<group>"; };
+>>>>>>> initial changes
 		D50920F62284A18100AC9580 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ItemList.strings; sourceTree = "<group>"; };
 		D578C36E229F099D00E08CFF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/SetupAutofill.strings; sourceTree = "<group>"; };
 		D578C370229F09B600E08CFF /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/SetupAutofill.strings; sourceTree = "<group>"; };
@@ -748,6 +772,7 @@
 				2C2EC56120ADAB1D00AF8C44 /* LockwiseScreenGraph.swift */,
 				2C2EC56320ADAB5400AF8C44 /* BaseTestCase.swift */,
 				7AA54CF29E6B76D6894A841E /* SnapshotHelper.swift */,
+				D4AC7F5422980EEC00F75ACF /* SnapshotsXCUITests.swift */,
 			);
 			path = LockwiseXCUITests;
 			sourceTree = "<group>";
@@ -1567,6 +1592,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D4AC7F5522980EEC00F75ACF /* SnapshotsXCUITests.swift in Sources */,
 				2C2EC55520ADA85A00AF8C44 /* LockwiseXCUITests.swift in Sources */,
 				2C2EC56420ADAB5400AF8C44 /* BaseTestCase.swift in Sources */,
 				2C2EC56220ADAB1D00AF8C44 /* LockwiseScreenGraph.swift in Sources */,

--- a/Lockbox.xcodeproj/xcshareddata/xcschemes/L10nSnapshotsTests.xcscheme
+++ b/Lockbox.xcodeproj/xcshareddata/xcschemes/L10nSnapshotsTests.xcscheme
@@ -73,13 +73,7 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "SnapshotsXCUITests">
-               </Test>
-               <Test
-                  Identifier = "SnapshotsXCUITests/testEntriesSortAndSearchSnapshots()">
-               </Test>
-               <Test
-                  Identifier = "SnapshotsXCUITests/testSettingsSnapshots()">
+                  Identifier = "LockwiseXCUITests">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/Lockbox.xcodeproj/xcshareddata/xcschemes/uispecs.xcscheme
+++ b/Lockbox.xcodeproj/xcshareddata/xcschemes/uispecs.xcscheme
@@ -71,6 +71,17 @@
                BlueprintName = "LockwiseXCUITests"
                ReferencedContainer = "container:Lockbox.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "LockwiseXCUITests">
+               </Test>
+               <Test
+                  Identifier = "SnapshotsXCUITests/testEntriesSortAndSearchSnapshots()">
+               </Test>
+               <Test
+                  Identifier = "SnapshotsXCUITests/testSettingsSnapshots()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/LockwiseXCUITests/LockwiseScreenGraph.swift
+++ b/LockwiseXCUITests/LockwiseScreenGraph.swift
@@ -146,7 +146,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.gesture(forAction: Action.OpenWebsite) { userState in
             app.buttons["open.button"].tap()
         }
-
+        screenState.backAction = navigationControllerBackAction
     }
 
     map.addScreenState(Screen.SortEntriesMenu) { screenState in
@@ -220,10 +220,11 @@ extension BaseTestCase {
         userState.fxaPassword = passwordTestAccountLogins
         userState.fxaUsername = emailTestAccountLogins
         navigator.goto(Screen.FxASigninScreenEmail)
-        waitforExistence(app.navigationBars["Get Started"])
-        waitforExistence(app.webViews.textFields["Email"], timeout: 10)
+        waitforExistence(app.buttons["closeButtonGetStartedNavBar"], timeout: 5)
+        snapshot("15LoginScreen" + CONTENT_SIZE)
         navigator.performAction(Action.FxATypeEmail)
         waitforExistence(app.webViews.secureTextFields["Password"])
+        snapshot("16PasswordScreen" + CONTENT_SIZE)
         navigator.performAction(Action.FxATypePassword)
     }
 
@@ -232,6 +233,7 @@ extension BaseTestCase {
             //If autofill is set this option will not appear
             sleep(5)
             if (app.buttons["setupAutofill.button"].exists) {
+                snapshot("13SkipAutofill" + CONTENT_SIZE)
                 app.buttons["notNow.button"].tap()
             }
         }
@@ -239,6 +241,7 @@ extension BaseTestCase {
 
     func tapOnFinishButton() {
         waitforExistence(app.buttons["finish.button"])
+        snapshot("12FinishButton" + CONTENT_SIZE)
         app.buttons["finish.button"].tap()
     }
 

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -11,23 +11,20 @@ class LockwiseXCUITests: BaseTestCase {
         waitforExistence(app.buttons["disconnectFirefoxLockwise.button"], timeout: 3)
         // Using taps directly because the action is intermittently failing on BB
         app.buttons["disconnectFirefoxLockwise.button"].tap()
-        //waitforExistence(app.buttons["Disconnect"], timeout: 3)
-        //app.buttons["Disconnect"].tap()
-        // This is the confirm Disconnect account
-        snapshot("14ConfirmDisconnect" + CONTENT_SIZE)
-        waitforExistence(app.buttons.element(boundBy: 3), timeout: 3)
-        app.buttons.element(boundBy: 3).tap()
+        waitforExistence(app.buttons["Disconnect"], timeout: 3)
+        app.buttons["Disconnect"].tap()
+
         waitforExistence(app.buttons["getStarted.button"], timeout: 30)
         navigator.nowAt(Screen.WelcomeScreen)
     }
 
     func testCheckEntryDetailsView() {
         loginToEntryListView()
-        
+
         XCTAssertNotEqual(app.tables.cells.count, 1)
         XCTAssertTrue(app.tables.cells.staticTexts[firstEntryEmail].exists)
         navigator.goto(Screen.EntryDetails)
-        
+
         // The fields appear
         XCTAssertTrue(app.cells["userNameItemDetail"].exists)
         XCTAssertTrue(app.cells["passwordItemDetail"].exists)
@@ -48,7 +45,7 @@ class LockwiseXCUITests: BaseTestCase {
         // Check the copy functionality with user name
         let userNameField = app.cells["userNameItemDetail"]
         userNameField.press(forDuration: 1)
-        snapshot("04CopyBanner" + CONTENT_SIZE)
+
         // Now check the clipboard
         if let userNameString = UIPasteboard.general.string {
             let value = app.cells["userNameItemDetail"].staticTexts.element(boundBy: 1).label
@@ -75,15 +72,14 @@ class LockwiseXCUITests: BaseTestCase {
     func testSettingsAccountUI() {
         loginToEntryListView()
         navigator.goto(Screen.AccountSettingsMenu)
-        snapshot("05AccountUI" + CONTENT_SIZE)
         waitforExistence(app.navigationBars["accountSetting.navigationBar"])
         XCTAssertTrue(app.staticTexts["username.Label"].exists)
         XCTAssertEqual(app.staticTexts["username.Label"].label, userNameAccountSetting)
         XCTAssertTrue(app.buttons["disconnectFirefoxLockwise.button"].exists, "The option to disconnect does not appear")
 
         // Try Cancel disconnecting the account
-//        navigator.performAction(Action.DisconnectFirefoxLockwiseCancel)
-//        waitforExistence(app.buttons["disconnectFirefoxLockwise.button"])
+        navigator.performAction(Action.DisconnectFirefoxLockwiseCancel)
+        waitforExistence(app.buttons["disconnectFirefoxLockwise.button"])
     }
 
     func testSettings() {
@@ -95,14 +91,12 @@ class LockwiseXCUITests: BaseTestCase {
         XCTAssertTrue(app.tables.cells.staticTexts["Firefox"].exists)
         XCTAssertTrue(app.tables.cells.staticTexts["Google Chrome"].exists)
         XCTAssertTrue(app.tables.cells.staticTexts["Safari"].exists)
-        snapshot("05OpenSitesMenu" + CONTENT_SIZE)
 
         // Check App Version not empty
         navigator.goto(Screen.SettingsMenu)
         // The app version option exists and it is not empty
         XCTAssertTrue(app.cells["appVersionSettingOption"].exists)
         XCTAssertNotEqual(app.cells.staticTexts.element(boundBy: 2).label, "")
-        snapshot("06SettingsMenu" + CONTENT_SIZE)
         
         // Check configure Autofill from settings
         if #available(iOS 12.0, *) {
@@ -119,26 +113,24 @@ class LockwiseXCUITests: BaseTestCase {
         // Checking if doing the steps directly works on bb
         waitforExistence(app.buttons["sorting.button"], timeout: 5)
         app.buttons["sorting.button"].tap()
-        snapshot("07SortingMenu" + CONTENT_SIZE)
-        //waitforExistence(app.buttons["Recently Used"])
-        //app.buttons["Recently Used"].tap()
+
+        waitforExistence(app.buttons["Recently Used"])
+        app.buttons["Recently Used"].tap()
         app.sheets.buttons.element(boundBy: 1).tap()
         waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
-//        let buttonLabelChanged = app.buttons["sorting.button"].label
-//        XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of logins (currently Recent)")
-        snapshot("08ListSortByRecent" + CONTENT_SIZE)
+        let buttonLabelChanged = app.buttons["sorting.button"].label
+        XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of logins (currently Recent)")
+
         // Check that the order has changed
         let firstCellRecent = app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0).label
         XCTAssertEqual(firstCellRecent, firstEntryRecentOrder )
 
         app.buttons["sorting.button"].tap()
-//        waitforExistence(app.buttons["Alphabetically"])
-//        app.buttons["Alphabetically"].tap()
-        waitforExistence(app.sheets.buttons.element(boundBy: 1))
-        app.sheets.buttons.element(boundBy: 0).tap()
+        waitforExistence(app.buttons["Alphabetically"])
+        app.buttons["Alphabetically"].tap()
         let buttonLabelInitally = app.buttons["sorting.button"].label
         waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
-//        XCTAssertEqual(buttonLabelInitally, "Select options for sorting your list of logins (currently A-Z)")
+        XCTAssertEqual(buttonLabelInitally, "Select options for sorting your list of logins (currently A-Z)")
 
         // Check that the order has changed again to its initial state
         let firstCellAlphabetically = app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0).label
@@ -148,7 +140,6 @@ class LockwiseXCUITests: BaseTestCase {
         let searchTextField = app.searchFields.firstMatch
         waitforExistence(searchTextField, timeout: 3)
         searchTextField.tap()
-        snapshot("09SearchOptions" + CONTENT_SIZE)
         searchTextField.typeText("a")
         // There should be the correct number of matches
         let aMatches = app.tables.cells.count
@@ -168,8 +159,6 @@ class LockwiseXCUITests: BaseTestCase {
         // There should not be any matches
         searchTextField.typeText("x")
         waitforExistence(app.cells.staticTexts["noMatchingEntries.label"])
-        print(app.debugDescription)
-        snapshot("10SearchNoMatches" + CONTENT_SIZE)
         let noMatches = app.tables.cells.count
         if  iPad() {
             // There are not matches but the number of rows shown, more on iPad
@@ -178,19 +167,16 @@ class LockwiseXCUITests: BaseTestCase {
             XCTAssertEqual(noMatches, 1)
         }
         // Tap on cacel
-        //app.buttons["Cancel"].tap()
-        app.buttons.element(boundBy: 4).tap()
+        app.buttons["Cancel"].tap()
         let searchFieldValueAfterCancel = searchTextField.placeholderValue
-//        XCTAssertEqual(searchFieldValueAfterCancel, "Search logins")
+        XCTAssertEqual(searchFieldValueAfterCancel, "Search logins")
         // Tap on 'x'
         searchTextField.tap()
         searchTextField.typeText("a")
-        //app.buttons["Clear text"].tap()
-        //app.buttons.element(boundBy: 3).tap()
-//        let searchFieldValueAfterXButton = searchTextField.value as! String
-//        XCTAssertEqual(searchFieldValueAfterXButton, "Search logins")
-//        app.buttons["Cancel"].tap()
-        app.buttons.element(boundBy: 4).tap()
+        app.buttons["Clear text"].tap()
+        let searchFieldValueAfterXButton = searchTextField.value as! String
+        XCTAssertEqual(searchFieldValueAfterXButton, "Search logins")
+        app.buttons["Cancel"].tap()
         navigator.nowAt(Screen.LockwiseMainPage)
     }
 
@@ -201,23 +187,23 @@ class LockwiseXCUITests: BaseTestCase {
         waitforExistence(app.navigationBars["settings.navigationBar"])
         navigator.goto(Screen.AutolockSettingsMenu)
         snapshot("11AutolockSettingsMenu" + CONTENT_SIZE)
-        //app.cells.staticTexts["Never"].tap()
+        app.cells.staticTexts["Never"].tap()
         navigator.goto(Screen.SettingsMenu)
-//        // Send app to background and launch it
-//        XCUIDevice.shared.press(.home)
-//        app.activate()
-//        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
-//        navigator.goto(Screen.LockwiseMainPage)
-//        navigator.performAction(Action.LockNow)
-//        waitforExistence(app.buttons["unlock.button"])
-//        app.buttons["unlock.button"].tap()
-//        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-//        waitforExistence(springboard.secureTextFields["Passcode field"])
-//        let passcodeInput = springboard.secureTextFields["Passcode field"]
-//        passcodeInput.tap()
-//        passcodeInput.typeText("0000\r")
-//        waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
-//        navigator.nowAt(Screen.LockwiseMainPage)
+        // Send app to background and launch it
+        XCUIDevice.shared.press(.home)
+        app.activate()
+        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
+        navigator.goto(Screen.LockwiseMainPage)
+        navigator.performAction(Action.LockNow)
+        waitforExistence(app.buttons["unlock.button"])
+        app.buttons["unlock.button"].tap()
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        waitforExistence(springboard.secureTextFields["Passcode field"])
+        let passcodeInput = springboard.secureTextFields["Passcode field"]
+        passcodeInput.tap()
+        passcodeInput.typeText("0000\r")
+        waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
+        navigator.nowAt(Screen.LockwiseMainPage)
     }
 
     // Verify SetAutofillNow

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -185,7 +185,6 @@ class LockwiseXCUITests: BaseTestCase {
         navigator.goto(Screen.SettingsMenu)
         waitforExistence(app.navigationBars["settings.navigationBar"])
         navigator.goto(Screen.AutolockSettingsMenu)
-        snapshot("11AutolockSettingsMenu" + CONTENT_SIZE)
         app.cells.staticTexts["Never"].tap()
         navigator.goto(Screen.LockwiseMainPage)
         // Send app to background and launch it

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -22,19 +22,16 @@ class LockwiseXCUITests: BaseTestCase {
     }
 
     func testCheckEntryDetailsView() {
-        snapshot("01Welcome" + CONTENT_SIZE)
         loginToEntryListView()
         
         XCTAssertNotEqual(app.tables.cells.count, 1)
         XCTAssertTrue(app.tables.cells.staticTexts[firstEntryEmail].exists)
-        snapshot("02EntryList" + CONTENT_SIZE)
         navigator.goto(Screen.EntryDetails)
         
         // The fields appear
         XCTAssertTrue(app.cells["userNameItemDetail"].exists)
         XCTAssertTrue(app.cells["passwordItemDetail"].exists)
         XCTAssertTrue(app.cells["webAddressItemDetail"].exists)
-        snapshot("03EntryDetail" + CONTENT_SIZE)
         // The value in each field is correct
         let userNameValue = app.cells["userNameItemDetail"].staticTexts.element(boundBy: 1).label
         XCTAssertEqual(userNameValue, firstEntryEmail)

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -116,7 +116,6 @@ class LockwiseXCUITests: BaseTestCase {
 
         waitforExistence(app.buttons["Recently Used"])
         app.buttons["Recently Used"].tap()
-        app.sheets.buttons.element(boundBy: 1).tap()
         waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
         let buttonLabelChanged = app.buttons["sorting.button"].label
         XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of logins (currently Recent)")

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -97,7 +97,7 @@ class LockwiseXCUITests: BaseTestCase {
         // The app version option exists and it is not empty
         XCTAssertTrue(app.cells["appVersionSettingOption"].exists)
         XCTAssertNotEqual(app.cells.staticTexts.element(boundBy: 2).label, "")
-        
+
         // Check configure Autofill from settings
         if #available(iOS 12.0, *) {
             navigator.goto(Screen.AutoFillSetUpInstructionsSettings)

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -8,12 +8,15 @@ class LockwiseXCUITests: BaseTestCase {
 
     override func tearDown() {
         navigator.goto(Screen.AccountSettingsMenu)
-        print(app.debugDescription)
         waitforExistence(app.buttons["disconnectFirefoxLockwise.button"], timeout: 3)
         // Using taps directly because the action is intermittently failing on BB
         app.buttons["disconnectFirefoxLockwise.button"].tap()
-        waitforExistence(app.buttons["Disconnect"], timeout: 3)
-        app.buttons["Disconnect"].tap()
+        //waitforExistence(app.buttons["Disconnect"], timeout: 3)
+        //app.buttons["Disconnect"].tap()
+        // This is the confirm Disconnect account
+        snapshot("14ConfirmDisconnect" + CONTENT_SIZE)
+        waitforExistence(app.buttons.element(boundBy: 3), timeout: 3)
+        app.buttons.element(boundBy: 3).tap()
         waitforExistence(app.buttons["getStarted.button"], timeout: 30)
         navigator.nowAt(Screen.WelcomeScreen)
     }
@@ -21,17 +24,17 @@ class LockwiseXCUITests: BaseTestCase {
     func testCheckEntryDetailsView() {
         snapshot("01Welcome" + CONTENT_SIZE)
         loginToEntryListView()
-
+        
         XCTAssertNotEqual(app.tables.cells.count, 1)
         XCTAssertTrue(app.tables.cells.staticTexts[firstEntryEmail].exists)
         snapshot("02EntryList" + CONTENT_SIZE)
         navigator.goto(Screen.EntryDetails)
-
+        
         // The fields appear
         XCTAssertTrue(app.cells["userNameItemDetail"].exists)
         XCTAssertTrue(app.cells["passwordItemDetail"].exists)
         XCTAssertTrue(app.cells["webAddressItemDetail"].exists)
-
+        snapshot("03EntryDetail" + CONTENT_SIZE)
         // The value in each field is correct
         let userNameValue = app.cells["userNameItemDetail"].staticTexts.element(boundBy: 1).label
         XCTAssertEqual(userNameValue, firstEntryEmail)
@@ -48,7 +51,7 @@ class LockwiseXCUITests: BaseTestCase {
         // Check the copy functionality with user name
         let userNameField = app.cells["userNameItemDetail"]
         userNameField.press(forDuration: 1)
-
+        snapshot("04CopyBanner" + CONTENT_SIZE)
         // Now check the clipboard
         if let userNameString = UIPasteboard.general.string {
             let value = app.cells["userNameItemDetail"].staticTexts.element(boundBy: 1).label
@@ -74,16 +77,16 @@ class LockwiseXCUITests: BaseTestCase {
 
     func testSettingsAccountUI() {
         loginToEntryListView()
-        snapshot("03Settings" + CONTENT_SIZE)
         navigator.goto(Screen.AccountSettingsMenu)
+        snapshot("05AccountUI" + CONTENT_SIZE)
         waitforExistence(app.navigationBars["accountSetting.navigationBar"])
         XCTAssertTrue(app.staticTexts["username.Label"].exists)
         XCTAssertEqual(app.staticTexts["username.Label"].label, userNameAccountSetting)
         XCTAssertTrue(app.buttons["disconnectFirefoxLockwise.button"].exists, "The option to disconnect does not appear")
 
         // Try Cancel disconnecting the account
-        navigator.performAction(Action.DisconnectFirefoxLockwiseCancel)
-        waitforExistence(app.buttons["disconnectFirefoxLockwise.button"])
+//        navigator.performAction(Action.DisconnectFirefoxLockwiseCancel)
+//        waitforExistence(app.buttons["disconnectFirefoxLockwise.button"])
     }
 
     func testSettings() {
@@ -95,13 +98,15 @@ class LockwiseXCUITests: BaseTestCase {
         XCTAssertTrue(app.tables.cells.staticTexts["Firefox"].exists)
         XCTAssertTrue(app.tables.cells.staticTexts["Google Chrome"].exists)
         XCTAssertTrue(app.tables.cells.staticTexts["Safari"].exists)
+        snapshot("05OpenSitesMenu" + CONTENT_SIZE)
 
         // Check App Version not empty
         navigator.goto(Screen.SettingsMenu)
         // The app version option exists and it is not empty
         XCTAssertTrue(app.cells["appVersionSettingOption"].exists)
         XCTAssertNotEqual(app.cells.staticTexts.element(boundBy: 2).label, "")
-
+        snapshot("06SettingsMenu" + CONTENT_SIZE)
+        
         // Check configure Autofill from settings
         if #available(iOS 12.0, *) {
             navigator.goto(Screen.AutoFillSetUpInstructionsSettings)
@@ -115,24 +120,28 @@ class LockwiseXCUITests: BaseTestCase {
         loginToEntryListView()
 
         // Checking if doing the steps directly works on bb
-        waitforExistence(app.buttons["sorting.button"], timeout: 3)
+        waitforExistence(app.buttons["sorting.button"], timeout: 5)
         app.buttons["sorting.button"].tap()
-        waitforExistence(app.buttons["Recently Used"])
-        app.buttons["Recently Used"].tap()
+        snapshot("07SortingMenu" + CONTENT_SIZE)
+        //waitforExistence(app.buttons["Recently Used"])
+        //app.buttons["Recently Used"].tap()
+        app.sheets.buttons.element(boundBy: 1).tap()
         waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
-        let buttonLabelChanged = app.buttons["sorting.button"].label
-        XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of logins (currently Recent)")
-
+//        let buttonLabelChanged = app.buttons["sorting.button"].label
+//        XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of logins (currently Recent)")
+        snapshot("08ListSortByRecent" + CONTENT_SIZE)
         // Check that the order has changed
         let firstCellRecent = app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0).label
         XCTAssertEqual(firstCellRecent, firstEntryRecentOrder )
 
         app.buttons["sorting.button"].tap()
-        waitforExistence(app.buttons["Alphabetically"])
-        app.buttons["Alphabetically"].tap()
+//        waitforExistence(app.buttons["Alphabetically"])
+//        app.buttons["Alphabetically"].tap()
+        waitforExistence(app.sheets.buttons.element(boundBy: 1))
+        app.sheets.buttons.element(boundBy: 0).tap()
         let buttonLabelInitally = app.buttons["sorting.button"].label
         waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
-        XCTAssertEqual(buttonLabelInitally, "Select options for sorting your list of logins (currently A-Z)")
+//        XCTAssertEqual(buttonLabelInitally, "Select options for sorting your list of logins (currently A-Z)")
 
         // Check that the order has changed again to its initial state
         let firstCellAlphabetically = app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0).label
@@ -142,6 +151,7 @@ class LockwiseXCUITests: BaseTestCase {
         let searchTextField = app.searchFields.firstMatch
         waitforExistence(searchTextField, timeout: 3)
         searchTextField.tap()
+        snapshot("09SearchOptions" + CONTENT_SIZE)
         searchTextField.typeText("a")
         // There should be the correct number of matches
         let aMatches = app.tables.cells.count
@@ -161,6 +171,8 @@ class LockwiseXCUITests: BaseTestCase {
         // There should not be any matches
         searchTextField.typeText("x")
         waitforExistence(app.cells.staticTexts["noMatchingEntries.label"])
+        print(app.debugDescription)
+        snapshot("10SearchNoMatches" + CONTENT_SIZE)
         let noMatches = app.tables.cells.count
         if  iPad() {
             // There are not matches but the number of rows shown, more on iPad
@@ -169,16 +181,19 @@ class LockwiseXCUITests: BaseTestCase {
             XCTAssertEqual(noMatches, 1)
         }
         // Tap on cacel
-        app.buttons["Cancel"].tap()
+        //app.buttons["Cancel"].tap()
+        app.buttons.element(boundBy: 4).tap()
         let searchFieldValueAfterCancel = searchTextField.placeholderValue
-        XCTAssertEqual(searchFieldValueAfterCancel, "Search logins")
+//        XCTAssertEqual(searchFieldValueAfterCancel, "Search logins")
         // Tap on 'x'
         searchTextField.tap()
         searchTextField.typeText("a")
-        app.buttons["Clear text"].tap()
-        let searchFieldValueAfterXButton = searchTextField.value as! String
-        XCTAssertEqual(searchFieldValueAfterXButton, "Search logins")
-        app.buttons["Cancel"].tap()
+        //app.buttons["Clear text"].tap()
+        //app.buttons.element(boundBy: 3).tap()
+//        let searchFieldValueAfterXButton = searchTextField.value as! String
+//        XCTAssertEqual(searchFieldValueAfterXButton, "Search logins")
+//        app.buttons["Cancel"].tap()
+        app.buttons.element(boundBy: 4).tap()
         navigator.nowAt(Screen.LockwiseMainPage)
     }
 
@@ -188,23 +203,24 @@ class LockwiseXCUITests: BaseTestCase {
         navigator.goto(Screen.SettingsMenu)
         waitforExistence(app.navigationBars["settings.navigationBar"])
         navigator.goto(Screen.AutolockSettingsMenu)
-        app.cells.staticTexts["Never"].tap()
-        navigator.goto(Screen.LockwiseMainPage)
-        // Send app to background and launch it
-        XCUIDevice.shared.press(.home)
-        app.activate()
-        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
-        navigator.goto(Screen.LockwiseMainPage)
-        navigator.performAction(Action.LockNow)
-        waitforExistence(app.buttons["unlock.button"])
-        app.buttons["unlock.button"].tap()
-        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        waitforExistence(springboard.secureTextFields["Passcode field"])
-        let passcodeInput = springboard.secureTextFields["Passcode field"]
-        passcodeInput.tap()
-        passcodeInput.typeText("0000\r")
-        waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
-        navigator.nowAt(Screen.LockwiseMainPage)
+        snapshot("11AutolockSettingsMenu" + CONTENT_SIZE)
+        //app.cells.staticTexts["Never"].tap()
+        navigator.goto(Screen.SettingsMenu)
+//        // Send app to background and launch it
+//        XCUIDevice.shared.press(.home)
+//        app.activate()
+//        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
+//        navigator.goto(Screen.LockwiseMainPage)
+//        navigator.performAction(Action.LockNow)
+//        waitforExistence(app.buttons["unlock.button"])
+//        app.buttons["unlock.button"].tap()
+//        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+//        waitforExistence(springboard.secureTextFields["Passcode field"])
+//        let passcodeInput = springboard.secureTextFields["Passcode field"]
+//        passcodeInput.tap()
+//        passcodeInput.typeText("0000\r")
+//        waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
+//        navigator.nowAt(Screen.LockwiseMainPage)
     }
 
     // Verify SetAutofillNow

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -188,7 +188,7 @@ class LockwiseXCUITests: BaseTestCase {
         navigator.goto(Screen.AutolockSettingsMenu)
         snapshot("11AutolockSettingsMenu" + CONTENT_SIZE)
         app.cells.staticTexts["Never"].tap()
-        navigator.goto(Screen.SettingsMenu)
+        navigator.goto(Screen.LockwiseMainPage)
         // Send app to background and launch it
         XCUIDevice.shared.press(.home)
         app.activate()

--- a/LockwiseXCUITests/SnapshotHelper.swift
+++ b/LockwiseXCUITests/SnapshotHelper.swift
@@ -18,8 +18,8 @@ import XCTest
 var deviceLanguage = ""
 var locale = ""
 
-func setupSnapshot(_ app: XCUIApplication) {
-    Snapshot.setupSnapshot(app)
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+    Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
 }
 
 func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
@@ -63,14 +63,16 @@ enum SnapshotError: Error, CustomDebugStringConvertible {
 @objcMembers
 open class Snapshot: NSObject {
     static var app: XCUIApplication?
+    static var waitForAnimations = true
     static var cacheDirectory: URL?
     static var screenshotsDirectory: URL? {
         return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
     }
 
-    open class func setupSnapshot(_ app: XCUIApplication) {
+    open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
         
         Snapshot.app = app
+        Snapshot.waitForAnimations = waitForAnimations
 
         do {
             let cacheDir = try pathPrefix()
@@ -114,10 +116,14 @@ open class Snapshot: NSObject {
         } catch {
             print("Couldn't detect/set locale...")
         }
-        if locale.isEmpty {
+        
+        if locale.isEmpty && !deviceLanguage.isEmpty {
             locale = Locale(identifier: deviceLanguage).identifier
         }
-        app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+        
+        if !locale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+        }
     }
 
     class func setLaunchArguments(_ app: XCUIApplication) {
@@ -149,10 +155,17 @@ open class Snapshot: NSObject {
 
         print("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
 
-        sleep(1) // Waiting for the animation to be finished (kind of)
+        if Snapshot.waitForAnimations {
+            sleep(1) // Waiting for the animation to be finished (kind of)
+        }
 
         #if os(OSX)
-            XCUIApplication().typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+            guard let app = self.app else {
+                print("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
             
             guard let app = self.app else {
@@ -178,7 +191,12 @@ open class Snapshot: NSObject {
             return
         #endif
 
-        let networkLoadingIndicator = XCUIApplication().otherElements.deviceStatusBars.networkLoadingIndicators.element
+        guard let app = self.app else {
+            print("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators.element
         let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
@@ -253,7 +271,11 @@ private extension XCUIElementQuery {
     }
 
     var deviceStatusBars: XCUIElementQuery {
-        let deviceWidth = XCUIApplication().windows.firstMatch.frame.width
+        guard let app = Snapshot.app else {
+            fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        }
+
+        let deviceWidth = app.windows.firstMatch.frame.width
 
         let isStatusBar = NSPredicate { (evaluatedObject, _) in
             guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
@@ -273,4 +295,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.12]
+// SnapshotHelperVersion [1.15]

--- a/LockwiseXCUITests/SnapshotsXCUITests.swift
+++ b/LockwiseXCUITests/SnapshotsXCUITests.swift
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+class SnapshotsXCUITests: BaseTestCase {
+    let preferredLanguage = NSLocale.preferredLanguages[0]
+    let currentDeviceLanguage = Locale.current.languageCode
+    
+    override func tearDown() {
+        navigator.goto(Screen.AccountSettingsMenu)
+        waitforExistence(app.buttons["disconnectFirefoxLockwise.button"], timeout: 3)
+        // Using taps directly because the action is intermittently failing on BB
+        app.buttons["disconnectFirefoxLockwise.button"].tap()
+        // This is the confirm Disconnect account
+        snapshot("14ConfirmDisconnect" + CONTENT_SIZE)
+        // Button is 3rd for ES,IT,EN, it is 2nd for DE, FR
+        print("idioma \(currentDeviceLanguage)")
+        if currentDeviceLanguage == "es" {
+            waitforExistence(app.buttons.element(boundBy: 3), timeout: 3)
+            app.buttons.element(boundBy: 3).tap()
+        } else if currentDeviceLanguage == "de-DE" {
+            waitforExistence(app.buttons.element(boundBy: 2), timeout: 3)
+            app.buttons.element(boundBy: 2).tap()
+        }
+        waitforExistence(app.buttons["getStarted.button"], timeout: 30)
+        navigator.nowAt(Screen.WelcomeScreen)
+    }
+    
+    func testCheckEntryDetailsViewSnapshot() {
+        snapshot("01Welcome" + CONTENT_SIZE)
+        loginToEntryListView()
+        
+        XCTAssertNotEqual(app.tables.cells.count, 1)
+        XCTAssertTrue(app.tables.cells.staticTexts[firstEntryEmail].exists)
+        snapshot("02EntryList" + CONTENT_SIZE)
+        navigator.goto(Screen.EntryDetails)
+        
+        // The fields appear
+        XCTAssertTrue(app.cells["userNameItemDetail"].exists)
+        XCTAssertTrue(app.cells["passwordItemDetail"].exists)
+        XCTAssertTrue(app.cells["webAddressItemDetail"].exists)
+        snapshot("03EntryDetail" + CONTENT_SIZE)
+        // The value in each field is correct
+        let userNameValue = app.cells["userNameItemDetail"].staticTexts.element(boundBy: 1).label
+        XCTAssertEqual(userNameValue, firstEntryEmail)
+        
+        let passwordValue = app.cells["passwordItemDetail"].staticTexts.element(boundBy: 1).label
+        XCTAssertEqual(passwordValue, "•••••••••••••")
+        
+        // Check the reveal Button
+        navigator.performAction(Action.RevealPassword)
+        
+        let passwordValueReveal = app.cells["passwordItemDetail"].staticTexts.element(boundBy: 1).label
+        XCTAssertEqual(passwordValueReveal, passwordTestAccountLogins)
+        
+        // Check the copy functionality with user name
+        let userNameField = app.cells["userNameItemDetail"]
+        userNameField.press(forDuration: 1)
+        snapshot("04CopyBanner" + CONTENT_SIZE)
+        // Now check the clipboard
+        if let userNameString = UIPasteboard.general.string {
+            let value = app.cells["userNameItemDetail"].staticTexts.element(boundBy: 1).label
+            XCTAssertNotNil(value)
+            XCTAssertEqual(userNameString, value, "Url matches with the UIPasteboard")
+        }
+        navigator.goto(Screen.LockwiseMainPage)
+    }
+
+    func testSettingsSnapshots() {
+        loginToEntryListView()
+        
+        // Check OpenSitesIn Menu option
+        navigator.goto(Screen.OpenSitesInMenu)
+        waitforExistence(app.navigationBars["openWebSitesIn.navigationBar"])
+        XCTAssertTrue(app.tables.cells.staticTexts["Firefox"].exists)
+        XCTAssertTrue(app.tables.cells.staticTexts["Google Chrome"].exists)
+        XCTAssertTrue(app.tables.cells.staticTexts["Safari"].exists)
+        snapshot("05OpenSitesMenu" + CONTENT_SIZE)
+        
+        // Check App Version not empty
+        navigator.goto(Screen.SettingsMenu)
+        // The app version option exists and it is not empty
+        XCTAssertTrue(app.cells["appVersionSettingOption"].exists)
+        XCTAssertNotEqual(app.cells.staticTexts.element(boundBy: 2).label, "")
+        snapshot("06SettingsMenu" + CONTENT_SIZE)
+        
+        // Check configure Autofill from settings
+        if #available(iOS 12.0, *) {
+            navigator.goto(Screen.AutoFillSetUpInstructionsSettings)
+            XCTAssertTrue(app.buttons["gotIt.button"].exists)
+        }
+        
+        // Check Autolock
+        navigator.goto(Screen.AutolockSettingsMenu)
+        snapshot("11AutolockSettingsMenu" + CONTENT_SIZE)
+        navigator.goto(Screen.SettingsMenu)
+        
+        // Check AccountSettings
+        navigator.goto(Screen.AccountSettingsMenu)
+        snapshot("05AccountUI" + CONTENT_SIZE)
+        waitforExistence(app.navigationBars["accountSetting.navigationBar"])
+        XCTAssertTrue(app.staticTexts["username.Label"].exists)
+        XCTAssertEqual(app.staticTexts["username.Label"].label, userNameAccountSetting)
+        XCTAssertTrue(app.buttons["disconnectFirefoxLockwise.button"].exists, "The option to disconnect does not appear")
+    }
+    
+    func testEntriesSortAndSearchSnapshots() {
+        let firstEntryRecentOrder = "bmo.com"
+        let firstEntryAphabeticallyOrder = "accounts.firefox.com"
+        loginToEntryListView()
+        
+        // Checking if doing the steps directly works on bb
+        waitforExistence(app.buttons["sorting.button"], timeout: 5)
+        app.buttons["sorting.button"].tap()
+        snapshot("07SortingMenu" + CONTENT_SIZE)
+
+        app.sheets.buttons.element(boundBy: 1).tap()
+        waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
+
+        snapshot("08ListSortByRecent" + CONTENT_SIZE)
+        // Check that the order has changed
+        let firstCellRecent = app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0).label
+        XCTAssertEqual(firstCellRecent, firstEntryRecentOrder )
+        
+        app.buttons["sorting.button"].tap()
+        waitforExistence(app.sheets.buttons.element(boundBy: 1))
+        app.sheets.buttons.element(boundBy: 0).tap()
+
+        waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
+
+        // Check that the order has changed again to its initial state
+        let firstCellAlphabetically = app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0).label
+        XCTAssertEqual(firstCellAlphabetically, firstEntryAphabeticallyOrder)
+        
+        // Search entries options
+        let searchTextField = app.searchFields.firstMatch
+        waitforExistence(searchTextField, timeout: 3)
+        searchTextField.tap()
+        snapshot("09SearchOptions" + CONTENT_SIZE)
+    
+        // There should not be any matches
+        searchTextField.typeText("x")
+        waitforExistence(app.cells.staticTexts["noMatchingEntries.label"])
+        snapshot("10SearchNoMatches" + CONTENT_SIZE)
+        let noMatches = app.tables.cells.count
+        if  iPad() {
+            // There are not matches but the number of rows shown, more on iPad
+            XCTAssertEqual(noMatches, 4)
+        } else {
+            XCTAssertEqual(noMatches, 1)
+        }
+        // Tap on cacel
+        app.buttons.element(boundBy: 4).tap()
+        navigator.nowAt(Screen.LockwiseMainPage)
+    }
+}

--- a/docs/AutomatedTests.md
+++ b/docs/AutomatedTests.md
@@ -1,0 +1,26 @@
+# Overview
+This document tries to describe the state of the test automation on Lockwise iOS
+
+# Current status
+Automated tests are running on BuddyBuild as part of each PR and when there is a new commit on master. 
+There are three schemes containing the different test types.
+- Lockbox scheme for unit tests
+- uispecs scheme for XCUITests checking the app at User Interface level
+- L10nSnapshotsTests for XCUITests in charge of generating the screenshots
+
+
+## Tests part of the development process
+For new PRs or new commits on master lockbox and uispecs tests are running. XCUITests are running on both iPhone (8) and iPad (Air2) simulator since they test the UI of the app, closer to what a real user would do, and there are differences that need to be checked depending on the device.
+
+
+## Tests to generate screenshots
+L10nSnapshots tests will be run in the future as part of the CI but is not defined yet how/how often.
+While the process is added to the CI, screenshots can be generated locally. The environment is set up once the repo is cloned and built so only these steps will be needed:
+
+1. From command line run: `fastlane snapshot`
+2. Screenshots will be saved in `fastlane/screenshots/` folder
+
+If screenshots are not saved, it may be necessary to create that folder locally.
+
+Current locales are defined in `fastlane/Snapfile` as well as the scheme to test. This file can be modified to add/remove locales while generating the screenshots.
+Once screenshots for each locale are generated, they are stored in [`drive`](https://drive.google.com/drive/folders/1dghwymAw5a8TbhhHZvA0Ag4qbgxJ1fDM?usp=sharing). This may change in the future but for now, they live there.

--- a/docs/AutomatedTests.md
+++ b/docs/AutomatedTests.md
@@ -23,4 +23,4 @@ While the process is added to the CI, screenshots can be generated locally. The 
 If screenshots are not saved, it may be necessary to create that folder locally.
 
 Current locales are defined in `fastlane/Snapfile` as well as the scheme to test. This file can be modified to add/remove locales while generating the screenshots.
-Once screenshots for each locale are generated, they are stored in [`drive`](https://drive.google.com/drive/folders/1dghwymAw5a8TbhhHZvA0Ag4qbgxJ1fDM?usp=sharing). This may change in the future but for now, they live there.
+Once screenshots for each locale are generated, they are stored in drive. This may change in the future but for now, they live there.

--- a/docs/AutomatedTests.md
+++ b/docs/AutomatedTests.md
@@ -23,4 +23,4 @@ While the process is added to the CI, screenshots can be generated locally. The 
 If screenshots are not saved, it may be necessary to create that folder locally.
 
 Current locales are defined in `fastlane/Snapfile` as well as the scheme to test. This file can be modified to add/remove locales while generating the screenshots.
-Once screenshots for each locale are generated, they are stored in drive. This may change in the future but for now, they live there.
+Once screenshots for each locale are generated, they are stored in [`drive`](https://drive.google.com/drive/folders/1dghwymAw5a8TbhhHZvA0Ag4qbgxJ1fDM?usp=sharing). This may change in the future but for now, they live there.

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -2,11 +2,10 @@
 
 # A list of devices you want to take the screenshots from
 devices([
-  "iPhone 8"
+  "iPhone X"
 ])
 
 languages([
-  "en-US",
   "de-DE"
 ])
 

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -6,8 +6,8 @@ devices([
 ])
 
 languages([
-  "de-DE"
+  "de-DE", "es-ES", "it-IT", "en-US", "fr-FR"
 ])
 
 # The name of the scheme which contains the UI Tests
-scheme "uispecs"
+scheme "L10nSnapshotsTests"

--- a/lockbox-ios/View/AccountSettingView.swift
+++ b/lockbox-ios/View/AccountSettingView.swift
@@ -39,7 +39,6 @@ class AccountSettingView: UIViewController {
             for: .normal
         )
         self.disclaimerLabel.text = String(format: Constant.string.disclaimerLabel, Constant.string.productLabel)
-        //self.unlinkAccountButton.accessibilityIdentifier = "disconnectConfirm"
     }
 }
 

--- a/lockbox-ios/View/AccountSettingView.swift
+++ b/lockbox-ios/View/AccountSettingView.swift
@@ -39,6 +39,7 @@ class AccountSettingView: UIViewController {
             for: .normal
         )
         self.disclaimerLabel.text = String(format: Constant.string.disclaimerLabel, Constant.string.productLabel)
+        //self.unlinkAccountButton.accessibilityIdentifier = "disconnectConfirm"
     }
 }
 

--- a/lockbox-ios/View/FxAView.swift
+++ b/lockbox-ios/View/FxAView.swift
@@ -76,6 +76,7 @@ extension FxAView: UIGestureRecognizerDelegate {
     fileprivate func setupNavBar() {
         let leftButton = UIButton(title: Constant.string.close, imageName: nil)
         leftButton.titleLabel?.font = .navigationButtonFont
+        leftButton.accessibilityIdentifier = "closeButtonGetStartedNavBar"
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         self.navigationController?.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.white]


### PR DESCRIPTION
Fixes #302 

This PR tries to set the environment up to have the screenshots back. In order to do that, I have created a new scheme for these tests, very similar to the existing ones but with some changes due to some options without ID (and without an easy way to add it) but with a workaround to use in the different languages selected.
Tests can be launched locally with `fastlane snapshot`command and they will run in all languages set. 
This is thought so that we can add this to CI soon if that's needed for localizers.
