### PR TITLE
980-xcuitests-fix-recentlyused

### DIFF
--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -119,6 +119,7 @@ class LockwiseXCUITests: BaseTestCase {
         sleep(1)
         navigator.performAction(Action.OpenWebsite)
         // Safari is open
+        waitforExistence(safari.buttons["URL"], timeout: 10)
         safari.terminate()
         app.launch()
         waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"], timeout: 5)

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -116,17 +116,15 @@ class LockwiseXCUITests: BaseTestCase {
         let userName = app.cells["userNameItemDetail"]
         userName.press(forDuration: 1)
 
-        sleep(1)
         waitforExistence(app.buttons["open.button"], timeout: 3)
-        //navigator.performAction(Action.OpenWebsite)
         app.buttons["open.button"].tap()
         // Safari is open
         waitforExistence(safari.buttons["URL"], timeout: 10)
         safari.terminate()
+        // Close Safari and re-open the app
         app.launch()
-        waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"], timeout: 5)
-        sleep(3)
-        navigator.nowAt(Screen.LockwiseMainPage)
+        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail], timeout: 20)
+
         // Checking if doing the steps directly works on bb
         waitforExistence(app.buttons["sorting.button"], timeout: 15)
         app.buttons["sorting.button"].tap()

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -117,8 +117,9 @@ class LockwiseXCUITests: BaseTestCase {
         userName.press(forDuration: 1)
 
         sleep(1)
-        waitforExistence(app.buttons["open.button"])
-        navigator.performAction(Action.OpenWebsite)
+        waitforExistence(app.buttons["open.button"], timeout: 3)
+        //navigator.performAction(Action.OpenWebsite)
+        app.buttons["open.button"].tap()
         // Safari is open
         waitforExistence(safari.buttons["URL"], timeout: 10)
         safari.terminate()

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -117,6 +117,7 @@ class LockwiseXCUITests: BaseTestCase {
         userName.press(forDuration: 1)
 
         sleep(1)
+        waitforExistence(app.buttons["open.button"])
         navigator.performAction(Action.OpenWebsite)
         // Safari is open
         waitforExistence(safari.buttons["URL"], timeout: 10)

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -115,12 +115,15 @@ class LockwiseXCUITests: BaseTestCase {
         // Copy its username and open the website
         let userName = app.cells["userNameItemDetail"]
         userName.press(forDuration: 1)
+
+        sleep(1)
         navigator.performAction(Action.OpenWebsite)
         // Safari is open
         safari.terminate()
-
         app.launch()
-
+        waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"], timeout: 5)
+        sleep(3)
+        navigator.nowAt(Screen.LockwiseMainPage)
         // Checking if doing the steps directly works on bb
         waitforExistence(app.buttons["sorting.button"], timeout: 15)
         app.buttons["sorting.button"].tap()

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -110,12 +110,23 @@ class LockwiseXCUITests: BaseTestCase {
         let firstEntryAphabeticallyOrder = "accounts.firefox.com"
         loginToEntryListView()
 
-        // Checking if doing the steps directly works on bb
-        waitforExistence(app.buttons["sorting.button"], timeout: 5)
-        app.buttons["sorting.button"].tap()
+        // Use one entry
+        app.tables.cells.staticTexts["testtesttesttest"].tap()
+        // Copy its username and open the website
+        let userName = app.cells["userNameItemDetail"]
+        userName.press(forDuration: 1)
+        navigator.performAction(Action.OpenWebsite)
+        // Safari is open
+        safari.terminate()
 
-        waitforExistence(app.buttons["Recently Used"])
+        app.launch()
+
+        // Checking if doing the steps directly works on bb
+        waitforExistence(app.buttons["sorting.button"], timeout: 15)
+        app.buttons["sorting.button"].tap()
+        waitforExistence(app.buttons["Recently Used"], timeout: 5)
         app.buttons["Recently Used"].tap()
+
         waitforExistence(app.navigationBars["firefoxLockwise.navigationBar"])
         let buttonLabelChanged = app.buttons["sorting.button"].label
         XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of logins (currently Recent)")


### PR DESCRIPTION
Fixes #980
This PR tries to use a login so that it is reliable the order when sorting by recent