### PR TITLE
Increase cancel button width in AutoFill list view

### DIFF
--- a/CredentialProvider/View/CredentialItemListView.swift
+++ b/CredentialProvider/View/CredentialItemListView.swift
@@ -62,7 +62,7 @@ extension ItemListView {
             toItem: nil,
             attribute: .notAnAttribute,
             multiplier: 1.0,
-            constant: 60)
+            constant: 70)
         )
         return button
     }

--- a/CredentialProvider/View/CredentialItemListView.swift
+++ b/CredentialProvider/View/CredentialItemListView.swift
@@ -62,7 +62,7 @@ extension ItemListView {
             toItem: nil,
             attribute: .notAnAttribute,
             multiplier: 1.0,
-            constant: 70)
+            constant: 90)
         )
         return button
     }


### PR DESCRIPTION
Closes #1047 

## Testing and Review Notes

- change device language to Spanish or German
- enable AutoFill in system settings
- open a website with a user/pass and press the "Key" 🔑 icon to open AutoFill list view
- observe the cancel button in the top left of navigation

Expected and Actual: "Cancelar" and "Abbrechen" should fit without elipses truncating it in the middle like "Can..ar"

## Screenshots or Videos

FR:

<img width="396" alt="image" src="https://user-images.githubusercontent.com/49511/59116387-aefbec00-8908-11e9-8fe6-07eee40d92b4.png">

ES (after):

<img width="400" alt="Screen Shot 2019-06-07 at 9 35 42 AM" src="https://user-images.githubusercontent.com/49511/59116400-b4f1cd00-8908-11e9-86a3-3180696dbbc8.png">

DE (after and to see how "crowded" with the large-to-small title moving into nav bar):

<img width="388" alt="Screen Shot 2019-06-07 at 9 41 34 AM" src="https://user-images.githubusercontent.com/49511/59116439-c5a24300-8908-11e9-94b4-6958f8961e00.png">


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests (UI specs)
- consider running this branch in the simulator and check for warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
