### PR TITLE
Fix UI Tests for deleted login

### DIFF
--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -106,12 +106,12 @@ class LockwiseXCUITests: BaseTestCase {
     }
 
     func testEntriesSortAndSearch() {
-        let firstEntryRecentOrder = "bmo.com"
+        let firstEntryRecentOrder = "arncyvuzox.co.uk"
         let firstEntryAphabeticallyOrder = "accounts.firefox.com"
         loginToEntryListView()
 
         // Use one entry
-        app.tables.cells.staticTexts["testtesttesttest"].tap()
+        app.tables.cells.staticTexts["fakeTester33333"].tap()
         // Copy its username and open the website
         let userName = app.cells["userNameItemDetail"]
         userName.press(forDuration: 1)
@@ -160,7 +160,7 @@ class LockwiseXCUITests: BaseTestCase {
         if  iPad() {
             XCTAssertEqual(aMatches, 111)
         } else {
-            XCTAssertEqual(aMatches, 108)
+            XCTAssertEqual(aMatches, 107)
         }
         // There should be less number of matches
         searchTextField.typeText("cc")

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -158,7 +158,7 @@ class LockwiseXCUITests: BaseTestCase {
         // There should be the correct number of matches
         let aMatches = app.tables.cells.count
         if  iPad() {
-            XCTAssertEqual(aMatches, 111)
+            XCTAssertEqual(aMatches, 110)
         } else {
             XCTAssertEqual(aMatches, 107)
         }


### PR DESCRIPTION
The `bmo.com` login is not present anymore (deleted?) causing the UI Tests to fail.