### PR TITLE
Fix ipad swipe to delete bug

### DIFF
--- a/Shared/Action/ItemListDisplayAction.swift
+++ b/Shared/Action/ItemListDisplayAction.swift
@@ -20,4 +20,5 @@ struct PullToRefreshAction: ItemListDisplayAction {
 
 struct ItemDeletedAction: ItemListDisplayAction {
     let name: String
+    let id: String
 }

--- a/Shared/Store/BaseDataStore.swift
+++ b/Shared/Store/BaseDataStore.swift
@@ -216,7 +216,7 @@ extension BaseDataStore {
                 .subscribe(onNext: { (record) in
                     if let record = record {
                         let title = record.hostname.titleFromHostname()
-                        self.dispatcher.dispatch(action: ItemDeletedAction(name: title))
+                        self.dispatcher.dispatch(action: ItemDeletedAction(name: title, id: record.id))
 
                         do {
                             try self.loginsStorage?.delete(id: id)

--- a/lockbox-ios/Presenter/ItemListPresenter.swift
+++ b/lockbox-ios/Presenter/ItemListPresenter.swift
@@ -208,6 +208,7 @@ class ItemListPresenter: BaseItemListPresenter {
     private func getDeletedItemObserver(id: String) -> AnyObserver<Void> {
         return Binder(self) { target, _ in
             target.dispatcher.dispatch(action: DataStoreAction.delete(id: id))
+            target.dispatcher.dispatch(action: MainRouteAction.list)
         }.asObserver()
     }
 }

--- a/lockbox-ios/Store/ItemDetailStore.swift
+++ b/lockbox-ios/Store/ItemDetailStore.swift
@@ -16,6 +16,7 @@ class ItemDetailStore: BaseItemDetailStore {
     private var lifecycleStore: LifecycleStore
     private var userDefaultStore: UserDefaultStore
     private var routeStore: RouteStore
+    private var itemListDisplayStore: ItemListDisplayStore
 
     private var _passwordRevealed = BehaviorRelay<Bool>(value: false)
 
@@ -34,13 +35,15 @@ class ItemDetailStore: BaseItemDetailStore {
             sizeClassStore: SizeClassStore = .shared,
             lifecycleStore: LifecycleStore = .shared,
             userDefaultStore: UserDefaultStore = .shared,
-            routeStore: RouteStore = .shared
+            routeStore: RouteStore = .shared,
+            itemListDisplayStore: ItemListDisplayStore = .shared
     ) {
         self.dataStore = dataStore
         self.sizeClassStore = sizeClassStore
         self.lifecycleStore = lifecycleStore
         self.userDefaultStore = userDefaultStore
         self.routeStore = routeStore
+        self.itemListDisplayStore = itemListDisplayStore
 
         super.init(dispatcher: dispatcher)
 
@@ -76,6 +79,14 @@ class ItemDetailStore: BaseItemDetailStore {
                 .filterNil()
                 .bind(to: self._itemDetailId)
                 .disposed(by: self.disposeBag)
+
+        self.itemListDisplayStore.listDisplay
+            .filterByType(class: ItemDeletedAction.self)
+            .filter { self._itemDetailId.value == $0.id }
+            .subscribe(onNext: { (action) in
+                self._itemDetailId.accept("")
+            })
+            .disposed(by: self.disposeBag)
 
         // If the splitview is being show
         // then after sync, select one item from the datastore to show

--- a/lockbox-iosTests/ItemListPresenterSpec.swift
+++ b/lockbox-iosTests/ItemListPresenterSpec.swift
@@ -586,7 +586,7 @@ class ItemListPresenterSpec: QuickSpec {
             describe("item deleted from store") {
                 beforeEach {
                     self.subject.onViewReady()
-                    self.itemListDisplayStore.itemListDisplaySubject.onNext(ItemDeletedAction(name: "mozilla.org"))
+                    self.itemListDisplayStore.itemListDisplaySubject.onNext(ItemDeletedAction(name: "mozilla.org", id: "1234"))
                 }
 
                 it("tells the view to display the toast") {


### PR DESCRIPTION
Fixes #1074

To test:
1. Log in on iPad
1. Tap on an item in the list
1. Swipe to delete that item
1. Verify that it no longer displays that item