### PR TITLE
Explicitly set navigation bar to an opaque color

### DIFF
--- a/Shared/View/BaseItemListView.swift
+++ b/Shared/View/BaseItemListView.swift
@@ -84,8 +84,6 @@ class BaseItemListView: UIViewController {
     }
 
     internal func styleNavigationBar() {
-        self.navigationController?.navigationBar.tintColor = UIColor.white
-
         self.navigationItem.title = Constant.string.productName
         self.navigationController?.navigationBar.tintColor = UIColor.white
         self.navigationController?.navigationBar.accessibilityIdentifier = "firefoxLockwise.navigationBar"
@@ -99,6 +97,15 @@ class BaseItemListView: UIViewController {
         self.searchController = self.getStyledSearchController()
 
         self.extendedLayoutIncludesOpaqueBars = true // Fixes tapping the status bar from showing partial pull-to-refresh
+
+        if #available(iOS 13.0, *) {
+            let navBarAppearance = UINavigationBarAppearance()
+            navBarAppearance.configureWithOpaqueBackground()
+            navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
+            navBarAppearance.backgroundColor = Constant.color.navBackgroundColor
+            self.navigationController?.navigationBar.standardAppearance = navBarAppearance
+            self.navigationController?.navigationBar.scrollEdgeAppearance = navBarAppearance
+        }
     }
 
     func getStyledSearchController() -> UISearchController {


### PR DESCRIPTION
Fixes #1097

## Testing and Review Notes

I was not able to successfully run the existing tests on this branch, but this change simply sets the navigation bar style to be non-transparent (see [this](https://stackoverflow.com/questions/56556254/in-ios13-the-status-bar-background-colour-is-different-from-the-navigation-bar-i) post describing [new iOS 13 human interface guideline changes](https://developer.apple.com/design/human-interface-guidelines/ios/bars/navigation-bars/) pertaining to navigation bars with large titles).

## Screenshots or Videos

![Screen Shot 2019-10-29 at 7 51 11 PM](https://user-images.githubusercontent.com/6138405/67817938-d99c3c00-fa85-11e9-836b-8d4b264c9dc9.png)

![Screen Shot 2019-10-29 at 7 50 35 PM](https://user-images.githubusercontent.com/6138405/67817940-db65ff80-fa85-11e9-8efe-472be2d0bba5.png)

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [x] double check the original issue to confirm it is fully satisfied
- [ ] add unit tests
  - optional: consider adding integration tests (UI specs)
- consider running this branch in the simulator and check for warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
