### PR TITLE
Update RxSwift to resolve Swift version build issue on buddybuild

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,6 @@
 github "Quick/Nimble" "v8.0.1"
 github "Quick/Quick" "v2.1.0"
-github "ReactiveX/RxSwift" "5.0.1"
+github "ReactiveX/RxSwift" "4b42d62e34e278f677e9788c1e4c2db2a65f88ce"
 github "RxSwiftCommunity/RxDataSources" "8d4ef9abd7fd093b9225aa3e833b46171c00cc38"
 github "RxSwiftCommunity/RxOptional" ~> 3.1.3
 github "adjust/ios_sdk" ~> 4.14.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Quick/Nimble" "v8.0.1"
 github "Quick/Quick" "v2.1.0"
-github "ReactiveX/RxSwift" "5.0.1"
+github "ReactiveX/RxSwift" "4b42d62e34e278f677e9788c1e4c2db2a65f88ce"
 github "RxSwiftCommunity/RxDataSources" "8d4ef9abd7fd093b9225aa3e833b46171c00cc38"
 github "RxSwiftCommunity/RxOptional" "3.7.0"
 github "adjust/ios_sdk" "v4.18.3"


### PR DESCRIPTION
## Fixes

After attempting to "Rebuild Without Cache", Buddybuild produces the following log error while trying to install RxSwift with Carthage and build project: 
```
    ***  Skipped installing RxSwift.framework binary due to the error:
67
    	"Incompatible Swift version - framework was built with 5.0.1 (swiftlang-1001.0.82.4 clang-1001.0.46.5) and the local version is 5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)."
```

This cartfile change fixes that error.

## Testing and Review Notes

Verify build is successful on buddybuild.