### PR TITLE
Update build number in release notes for 1.7.0 

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 1.7.0 (Build 3874)
+## 1.7.0 (Build 3871)
 
 _Date: 2019-11-15_
 


### PR DESCRIPTION
Update release notes for 1.7.0 to reflect build number uploaded to testflight - [#3871](https://dashboard.buddybuild.com/apps/5a0ddb736e19370001034f85/build/5dce82eb82fec300014b073c)

