### PR TITLE
Fix for Webkit launch crash

### DIFF
--- a/lockbox-ios/Store/AccountStore.swift
+++ b/lockbox-ios/Store/AccountStore.swift
@@ -80,6 +80,7 @@ class AccountStore: BaseAccountStore {
     override func initialized() {
         self.dispatcher.register
                 .filterByType(class: AccountAction.self)
+                .observeOn(MainScheduler.instance)
                 .subscribe(onNext: { action in
                     switch action {
                     case .oauthRedirect(let url):
@@ -149,12 +150,12 @@ extension AccountStore {
             self.webData.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: records) { }
         }
 
-        self.urlCache.removeAllCachedResponses()
+        urlCache.removeAllCachedResponses()
 
-        self._profile.onNext(nil)
-        self._syncCredentials.onNext(nil)
+        _profile.onNext(nil)
+        _syncCredentials.onNext(nil)
 
-        self.initFxa()
+        initFxa()
     }
 
     private func clearOldKeychainValues() {


### PR DESCRIPTION
Fixes #1147 

The `Dispatcher.register` Observable must be subscribed to on the main thread, otherwise it causes crashes when certain resulting functions are called on background threads. This resolves issue 1147, which was the result of webkit code being called on a background thread when a user's token expires.  

The function that was called on a background thread, causing crashes:
```
/// AccountStore

private func clear() {
        for identifier in KeychainKey.allValues {
            _ = self.keychainWrapper.removeObject(forKey: identifier.rawValue)
        }

       // Crash occurred here
        self.webData.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
            self.webData.removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), for: records) { }
        }

        urlCache.removeAllCachedResponses()

        _profile.onNext(nil)
        _syncCredentials.onNext(nil)

        initFxa()
    }
```

Connected to #[Application Services Issue 2279](https://github.com/mozilla/application-services/issues/2279)