### PR TITLE
1153-xcuitests-fix-iPad-new-fxa-login-page

### DIFF
--- a/LockwiseXCUITests/LockwiseScreenGraph.swift
+++ b/LockwiseXCUITests/LockwiseScreenGraph.swift
@@ -97,6 +97,9 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.gesture(forAction: Action.FxATypeEmail, transitionTo: Screen.FxASigninScreenPassword) { userState in
             app.webViews.textFields["Email"].tap()
             app.webViews.textFields["Email"].typeText(userState.fxaUsername!)
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                app.webViews.textFields["Email"].tap()
+            }
             app.webViews.buttons["Continue"].tap()
         }
     }

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -189,7 +189,11 @@ class LockwiseXCUITests: BaseTestCase {
         searchTextField.typeText("a")
         // There should be the correct number of matches
         let aMatches = app.tables.cells.count
-        XCTAssertEqual(aMatches, 97)
+        if  iPad() {
+            XCTAssertEqual(aMatches, 100 )
+        } else {
+            XCTAssertEqual(aMatches, 97)
+        }
         // There should be less number of matches
         searchTextField.typeText("cc")
         let accMatches = app.tables.cells.count

--- a/LockwiseXCUITests/LockwiseXCUITests.swift
+++ b/LockwiseXCUITests/LockwiseXCUITests.swift
@@ -189,11 +189,7 @@ class LockwiseXCUITests: BaseTestCase {
         searchTextField.typeText("a")
         // There should be the correct number of matches
         let aMatches = app.tables.cells.count
-        if  iPad() {
-            XCTAssertEqual(aMatches, 100)
-        } else {
-            XCTAssertEqual(aMatches, 97)
-        }
+        XCTAssertEqual(aMatches, 97)
         // There should be less number of matches
         searchTextField.typeText("cc")
         let accMatches = app.tables.cells.count


### PR DESCRIPTION
Fixes #1153 
This is a workaround for iPad sim to go over the new ui in the fxa login page