### PR TITLE
Fixed Issue #1133

### DIFF
--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -26,6 +26,20 @@ class ItemListView: BaseItemListView {
         setupRefresh()
         setupSwipeDelete()
         presenter?.onViewReady()
+        backgroundModeObserver()
+    }
+    
+    private func backgroundModeObserver() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(scrollTableViewToTop),
+                                               name: UIApplication.didEnterBackgroundNotification,
+                                               object: nil)
+    }
+    
+    @objc private func scrollTableViewToTop() {
+        self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0),
+                                   at: UITableView.ScrollPosition.top,
+                                   animated: true)
     }
 
     override func styleNavigationBar() {

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -28,6 +28,17 @@ class ItemListView: BaseItemListView {
         presenter?.onViewReady()
         backgroundModeObserver()
     }
+
+    override func styleNavigationBar() {
+        super.styleNavigationBar()
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.prefButton)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: self.sortingButton)
+    }
+
+    override func createPresenter() -> BaseItemListPresenter {
+        return ItemListPresenter(view: self)
+    }
     
     private func backgroundModeObserver() {
         NotificationCenter.default.addObserver(self,
@@ -40,17 +51,6 @@ class ItemListView: BaseItemListView {
         self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0),
                                    at: UITableView.ScrollPosition.top,
                                    animated: true)
-    }
-
-    override func styleNavigationBar() {
-        super.styleNavigationBar()
-
-        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.prefButton)
-        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: self.sortingButton)
-    }
-
-    override func createPresenter() -> BaseItemListPresenter {
-        return ItemListPresenter(view: self)
     }
 }
 


### PR DESCRIPTION
Fixes #1133 

Fixed issue that caused UITableView to leave space above first item after returning to from background mode. 

## Testing and Review Notes

Open app. Log in. Pull down TableView to refresh. While TableView is still refreshing, exit out of the app into background mode. Open the app again, and the there should be no space at the top of the TableView.

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests (UI specs)
- consider running this branch in the simulator and check for warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
