### PR TITLE
Fixed Issue #1171: textValue UITextField no longer shifts left when editing

### DIFF
--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -168,6 +168,7 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
                     .disposed(by: cell.disposeBag)
                 
                 cell.textValue.textColor = cellConfiguration.valueFontColor
+                cell.textValue.textAlignment = .right
                 
                 cell.accessibilityLabel = cellConfiguration.accessibilityLabel
                 cell.accessibilityIdentifier = cellConfiguration.accessibilityId


### PR DESCRIPTION
Fixes #1171 

Username and password no longer shifts left when the user begins editing.

## Testing and Review Notes

Open app and enter editing mode. Click either username or password to start editing. Text should no longer shift left.
