### PR TITLE
Fixed Issue #1168: UITextField no longer covered by Reveal Button in ItemDetailView

### DIFF
--- a/lockbox-ios/Storyboard/Base.lproj/ItemDetail.storyboard
+++ b/lockbox-ios/Storyboard/Base.lproj/ItemDetail.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_5" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,7 +20,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="osx-2O-xPR">
-                                    <rect key="frame" x="0.0" y="117.33333333333334" width="414" height="44"/>
+                                    <rect key="frame" x="0.0" y="130" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q5w-8r-WF1">
@@ -47,14 +45,14 @@
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="itemdetailcell" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="itemdetailcell" id="93Q-p9-9a2" customClass="ItemDetailCell" customModule="Lockbox" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="55.333333333333343" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.333332061767578" width="414" height="56.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="93Q-p9-9a2" id="H0O-36-Vfq">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="56.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t0H-71-xTp">
-                                                    <rect key="frame" x="15" y="12" width="33" height="5.6666666666666679"/>
+                                                    <rect key="frame" x="15" y="12" width="33" height="15.666666666666664"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                     <color key="textColor" red="0.45098039215686275" green="0.45098039215686275" blue="0.45098039215686275" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                     <nil key="highlightedColor"/>
@@ -62,14 +60,8 @@
                                                         <fragment content="This is a placeholder string for development purposes only"/>
                                                     </attributedString>
                                                 </label>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="av2-cE-3aJ">
-                                                    <rect key="frame" x="15" y="17.666666666666668" width="8" height="17.000000000000004"/>
-                                                    <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mhp-Pp-rfw">
-                                                    <rect key="frame" x="321" y="-4.3333333333333321" width="43" height="52.333333333333329"/>
+                                                    <rect key="frame" x="321" y="2.3333333333333321" width="43" height="52"/>
                                                     <accessibility key="accessibilityConfiguration" label="Reveal password in plaintext"/>
                                                     <inset key="contentEdgeInsets" minX="10" minY="15" maxX="15" maxY="15"/>
                                                     <state key="normal" image="reveal-eye"/>
@@ -83,7 +75,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
                                                 <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tbk-ki-qGK" userLabel="Open Button">
-                                                    <rect key="frame" x="366" y="-4.3333333333333321" width="43" height="52.333333333333329"/>
+                                                    <rect key="frame" x="366" y="2.3333333333333321" width="43" height="52"/>
                                                     <accessibility key="accessibilityConfiguration" label="Open this web address in browser"/>
                                                     <inset key="contentEdgeInsets" minX="10" minY="15" maxX="15" maxY="15"/>
                                                     <state key="normal" image="open"/>
@@ -97,7 +89,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
                                                 <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HfY-Wo-gMH" userLabel="Copy Button">
-                                                    <rect key="frame" x="366" y="-4.3333333333333321" width="43" height="52.333333333333329"/>
+                                                    <rect key="frame" x="366" y="2.3333333333333321" width="43" height="52"/>
                                                     <accessibility key="accessibilityConfiguration" label="Copy value"/>
                                                     <inset key="contentEdgeInsets" minX="10" minY="15" maxX="15" maxY="15"/>
                                                     <state key="normal" image="copy"/>
@@ -110,15 +102,20 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="copy.button"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
+                                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="av2-cE-3aJ">
+                                                    <rect key="frame" x="15" y="27.666666666666671" width="4" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstItem="Mhp-Pp-rfw" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="av2-cE-3aJ" secondAttribute="trailing" id="42D-68-Zbs"/>
                                                 <constraint firstItem="HfY-Wo-gMH" firstAttribute="centerY" secondItem="H0O-36-Vfq" secondAttribute="centerY" id="6fI-th-46b"/>
                                                 <constraint firstItem="t0H-71-xTp" firstAttribute="leading" secondItem="H0O-36-Vfq" secondAttribute="leading" constant="15" id="CgT-og-AF4"/>
                                                 <constraint firstItem="av2-cE-3aJ" firstAttribute="top" secondItem="t0H-71-xTp" secondAttribute="bottom" id="FGj-DV-At5"/>
                                                 <constraint firstAttribute="trailing" secondItem="HfY-Wo-gMH" secondAttribute="trailing" constant="5" id="M3P-rq-PHQ"/>
                                                 <constraint firstItem="Tbk-ki-qGK" firstAttribute="centerY" secondItem="H0O-36-Vfq" secondAttribute="centerY" id="NXp-wa-p77"/>
                                                 <constraint firstItem="Mhp-Pp-rfw" firstAttribute="centerY" secondItem="H0O-36-Vfq" secondAttribute="centerY" id="WVb-Or-XM2"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="av2-cE-3aJ" secondAttribute="trailing" constant="60" id="gSL-Fh-clq"/>
                                                 <constraint firstItem="HfY-Wo-gMH" firstAttribute="leading" secondItem="Mhp-Pp-rfw" secondAttribute="trailing" constant="2" id="hzs-ve-hR2"/>
                                                 <constraint firstAttribute="bottom" secondItem="av2-cE-3aJ" secondAttribute="bottom" constant="9" id="pvA-gV-mEF"/>
                                                 <constraint firstItem="t0H-71-xTp" firstAttribute="top" secondItem="H0O-36-Vfq" secondAttribute="top" constant="12" id="qEP-rE-sRP"/>
@@ -130,18 +127,18 @@
                                             <outlet property="copyButton" destination="HfY-Wo-gMH" id="IrI-SL-jiV"/>
                                             <outlet property="openButton" destination="Tbk-ki-qGK" id="SAe-N5-GUR"/>
                                             <outlet property="revealButton" destination="Mhp-Pp-rfw" id="9gv-8e-xXc"/>
-                                            <outlet property="title" destination="t0H-71-xTp" id="OlC-Hz-PBf"/>
                                             <outlet property="textValue" destination="av2-cE-3aJ" id="a5G-v5-4tQ"/>
+                                            <outlet property="title" destination="t0H-71-xTp" id="OlC-Hz-PBf"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="YaD-WB-pbb" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="4I2-rO-7Qh" secondAttribute="bottom" constant="-20" id="2ZU-bL-E9J"/>
-                            <constraint firstItem="YaD-WB-pbb" firstAttribute="centerX" secondItem="4I2-rO-7Qh" secondAttribute="centerX" id="7wI-eF-AR9"/>
+                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="4I2-rO-7Qh" secondAttribute="bottom" constant="-20" id="2ZU-bL-E9J"/>
+                            <constraint firstAttribute="centerX" secondItem="4I2-rO-7Qh" secondAttribute="centerX" id="7wI-eF-AR9"/>
                             <constraint firstItem="4I2-rO-7Qh" firstAttribute="leading" secondItem="KzI-mp-fPN" secondAttribute="leading" id="JZg-bg-E7B"/>
-                            <constraint firstItem="YaD-WB-pbb" firstAttribute="width" relation="lessThanOrEqual" secondItem="3Hr-tN-JYo" secondAttribute="width" id="PAs-Ln-X7h"/>
+                            <constraint firstAttribute="width" relation="lessThanOrEqual" secondItem="3Hr-tN-JYo" secondAttribute="width" id="PAs-Ln-X7h"/>
                             <constraint firstItem="4I2-rO-7Qh" firstAttribute="height" secondItem="KzI-mp-fPN" secondAttribute="height" id="Qr0-wP-XZD"/>
                             <constraint firstItem="4I2-rO-7Qh" firstAttribute="width" secondItem="KzI-mp-fPN" secondAttribute="width" id="U4U-2H-wOZ"/>
                             <constraint firstItem="4I2-rO-7Qh" firstAttribute="top" secondItem="KzI-mp-fPN" secondAttribute="top" id="qDT-gp-FgI"/>
@@ -155,14 +152,14 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DuT-js-ucH" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="826.39999999999998" y="139.880059970015"/>
+            <point key="canvasLocation" x="826.08695652173924" y="139.28571428571428"/>
         </scene>
     </scenes>
+    <color key="tintColor" red="0.34901960784313724" green="0.16470588235294117" blue="0.79607843137254897" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
     <resources>
         <image name="copy" width="18" height="18"/>
         <image name="hide-eye" width="18" height="18"/>
         <image name="open" width="18" height="18"/>
         <image name="reveal-eye" width="18" height="18"/>
     </resources>
-    <color key="tintColor" red="0.34901960784313724" green="0.16470588235294117" blue="0.79607843137254897" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
 </document>


### PR DESCRIPTION
Fixes #1168 

Fixed issue that caused the Reveal button to cover long passwords. This issue was caused by a minor bug in ItemDetail.storyboard . Below are the screenshots of the constraint that was changed. The textValue right anchor now touches the left anchor of the reveal button.

## Before Change

<img width="1258" alt="Screen Shot 2020-06-02 at 2 44 39 PM" src="https://user-images.githubusercontent.com/35638500/83563282-850be400-a4e0-11ea-8e6e-4ebe248a4677.png">

## After Change

<img width="1257" alt="Screen Shot 2020-06-02 at 2 44 51 PM" src="https://user-images.githubusercontent.com/35638500/83563270-80473000-a4e0-11ea-83c9-e5a280553a90.png">

## Testing and Review Notes

Go to item detail view and enter a long password. Reveal button should not appear over the password text.
