### PR TITLE
Fixed Issue #1193: Added space below Lock Now button 

### DIFF
--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -194,7 +194,8 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
                 }
                 
                 if let revealObserver = cellConfiguration.revealPasswordObserver {
-                    cell.textValue.font = UIFont(name: "Menlo-Regular", size: 16)
+                    // Font is not consistent with app. Uncomment this line out if this was intentional 
+//                    cell.textValue.font = UIFont(name: "Menlo-Regular", size: 16)
                     
                     cell.revealButton.rx.tap
                         .map { _ -> Bool in

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -194,9 +194,6 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
                 }
                 
                 if let revealObserver = cellConfiguration.revealPasswordObserver {
-                    // Font is not consistent with app. Uncomment this line out if this was intentional 
-//                    cell.textValue.font = UIFont(name: "Menlo-Regular", size: 16)
-                    
                     cell.revealButton.rx.tap
                         .map { _ -> Bool in
                             cell.revealButton.isSelected = !cell.revealButton.isSelected

--- a/lockbox-ios/View/SettingListView.swift
+++ b/lockbox-ios/View/SettingListView.swift
@@ -177,6 +177,7 @@ extension SettingListView {
         footerView.frame = frame
 
         self.tableView.tableFooterView = footerView
+        self.tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 18, right: 0)
     }
 }
 


### PR DESCRIPTION
Fixes #1193 

Added space below Lock Now button in settings.

## Testing and Review Notes

Go to Settings page. Scroll to bottom on TableView. There should be a space of 18px below the last cell.

## Screenshots or Videos

![Simulator Screen Shot - iPhone 8 - 2020-05-18 at 23 37 49](https://user-images.githubusercontent.com/35638500/82285255-a4dbcd80-9960-11ea-98a1-58b1abbea41f.png)
