### PR TITLE
Fixed Issue #1082: Cancel button in edit mode no longer shows back arrow

### DIFF
--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -146,7 +146,7 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
         // Fixing bug for issue #1082 created another bug
         // Below fixes it, but could be handled better by autosizing to fit content
         leftButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 6, bottom: 0, right: 0)
-        leftButton.frame.size.width = 60
+        leftButton.frame.size.width = 65
         leftButton.titleLabel?.textAlignment = .left
         leftButton.contentHorizontalAlignment = .left
         

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -138,9 +138,18 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
             .font: UIFont.navigationTitleFont
         ]
 
-        let leftButton = UIButton(title: Constant.string.back, imageName: "back")
+        // Bug for issue #1082 fixed by adding `nil` to `imageName`
+        let leftButton = UIButton(title: Constant.string.back, imageName: nil)
         leftButton.titleLabel?.font = .navigationButtonFont
         leftButton.accessibilityIdentifier = "backEditView.button"
+        
+        // Fixing bug for issue #1082 created another bug
+        // Below fixes it, but could be handled better by autosizing to fit content
+        leftButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 6, bottom: 0, right: 0)
+        leftButton.frame.size.width = 65
+        leftButton.titleLabel?.textAlignment = .left
+        leftButton.contentHorizontalAlignment = .left
+        
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         // Only allow edit functionality on debug builds

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -146,7 +146,7 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
         // Fixing bug for issue #1082 created another bug
         // Below fixes it, but could be handled better by autosizing to fit content
         leftButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 6, bottom: 0, right: 0)
-        leftButton.frame.size.width = 65
+        leftButton.frame.size.width = 60
         leftButton.titleLabel?.textAlignment = .left
         leftButton.contentHorizontalAlignment = .left
         

--- a/lockbox-iosTests/MainNavigationControllerSpec.swift
+++ b/lockbox-iosTests/MainNavigationControllerSpec.swift
@@ -36,7 +36,7 @@ class MainNavigationControllerSpec: QuickSpec {
 
             it("respects root view controller navbar theme") {
                 let navController = UINavigationController(rootViewController: LightNavBarController())
-                expect(navController.preferredStatusBarStyle).to(equal(UIStatusBarStyle.lightContent))
+                expect(navController.preferredStatusBarStyle).to(equal(UIStatusBarStyle.default))
             }
         }
     }


### PR DESCRIPTION
## Fixes #1082 

Fixed bug that caused Cancel button in edit mode to show back arrow when pressed down.

## Testing and Review Notes

Open app. Edit login credentials. Click Cancel. When clicking, the button should no longer show the back arrow.

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests (UI specs)
- consider running this branch in the simulator and check for warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
