### PR TITLE
Fixed Issues #1152, #1156, #1233, and #1172: Fixed issues related to Discard, Save, and Reveal password in Edit mode

### DIFF
--- a/Shared/Common/Resources/BaseConstants.swift
+++ b/Shared/Common/Resources/BaseConstants.swift
@@ -47,6 +47,7 @@ class Constant {
         static let activeNavSearchBackgroundColor = UIColor(red: 39, green: 25, blue: 72)
         static let navSerachTextColor = UIColor.white
         static let navSearchPlaceholderTextColor = UIColor(white: 1.0, alpha: 0.8)
+        static let itemDetailHeaderGray = UIColor(hex: 0x737373)
     }
 
     struct number {

--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -41,6 +41,7 @@ extension Constant.string {
     static let fieldNameCopied = NSLocalizedString("fieldNameCopied", value: "%@ copied", comment: "Alert text when a field has been copied. %@ will be replaced with the field name that was copied")
     static let notes = NSLocalizedString("notes", value: "Notes", comment: "Section title for the notes field on the item detail screen")
     static let password = NSLocalizedString("password", value: "Password", comment: "Section title text for the password on the item detail screen")
+    static let editedPassword = NSLocalizedString("editedPassword", value: "editedPassword", comment: "Used within ItemDetailView")
     static let recent = NSLocalizedString("recent", value: "Recent", comment: "Button title when logins list is sorted by most recently used login")
     static let recentlyUsed = NSLocalizedString("recently_used", value: "Recently Used", comment: "Label for the option sheet action allowing users to sort the logins list by the most recently used logins")
     static let unlockFaceID = NSLocalizedString("unlock_with_faceid", value: "Unlock with Face ID", comment: "Label for the button to unlock the device using Face ID")

--- a/lockbox-ios/Presenter/ItemDetailPresenter.swift
+++ b/lockbox-ios/Presenter/ItemDetailPresenter.swift
@@ -354,6 +354,13 @@ class ItemDetailPresenter {
 // helpers
 extension ItemDetailPresenter {
     private func configurationForLogin(_ login: LoginRecord?) -> [ItemDetailSectionModel] {
+        
+        // MARK: Create an observer similar to `rightBarButtonTapped` to get the latest values being editted withLatestFrom(editingObservable)
+        // MARK: Replace `login?.password ?? ""` below with the values observed (described above)
+        // MARK: Reason: configurationForLogin(_ login: LoginRecord?) is called once during initialization
+        // MARK: We need something that is overridden everything the textfield is editted.
+        // MARK: Need to make sure to not take the value directly from textfield because it will return something like this: "•••••••••••••"
+        
         let itemPassword: String = login?.password ?? ""
 
         let passwordTextDriver = itemDetailStore.passwordRevealed

--- a/lockbox-ios/Presenter/ItemDetailPresenter.swift
+++ b/lockbox-ios/Presenter/ItemDetailPresenter.swift
@@ -85,7 +85,7 @@ class ItemDetailPresenter {
                 if val.count > self.editedPassword.count {
                     
                     let index = val.index(val.startIndex, offsetBy: self.editedPassword.count)
-                    self.editedPassword = self.editedPassword + val.suffix(from: index)
+                    self.editedPassword = "\(self.editedPassword)\(val.suffix(from: index))"
                     
                 } else {
                     

--- a/lockbox-ios/Presenter/ItemDetailPresenter.swift
+++ b/lockbox-ios/Presenter/ItemDetailPresenter.swift
@@ -306,13 +306,22 @@ class ItemDetailPresenter {
                     let (username, _, webAddress, editing, item) = tuple
                     if editing {
                         if let item = item {
-                            item.hostname = webAddress
-                            item.username = username
-                            item.password = self.editedPassword
-                            self.savedLoginInfo[Constant.string.username] = item.username
-                            self.savedLoginInfo[Constant.string.password] = item.password
-                            return [DataStoreAction.update(login: item),
-                                    ItemDetailDisplayAction.viewMode]
+                            if !username.isEmpty && !self.editedPassword.isEmpty {
+                                
+                                item.hostname = webAddress
+                                item.username = username
+                                item.password = self.editedPassword
+                                self.savedLoginInfo[Constant.string.username] = item.username
+                                self.savedLoginInfo[Constant.string.password] = item.password
+                                return [DataStoreAction.update(login: item),
+                                        ItemDetailDisplayAction.viewMode]
+                                
+                            } else {
+                                
+                                // End editing
+                                // Make textfield background light red
+                                
+                            }
                         }
                     } else {
                         return [ItemDetailDisplayAction.editMode]

--- a/lockbox-ios/Presenter/ItemDetailPresenter.swift
+++ b/lockbox-ios/Presenter/ItemDetailPresenter.swift
@@ -310,7 +310,8 @@ class ItemDetailPresenter {
                             
                             // Saves edited login credentials
                             // Displays error if username or password is empy
-                            if !username.isEmpty && !self.editedPassword.isEmpty {
+                            if !username.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                && !self.editedPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                                 
                                 // clear errors
                                 self.dismissErrors()

--- a/lockbox-ios/Presenter/ItemDetailPresenter.swift
+++ b/lockbox-ios/Presenter/ItemDetailPresenter.swift
@@ -85,7 +85,7 @@ class ItemDetailPresenter {
                 if val.count > self.editedPassword.count {
                     
                     let index = val.index(val.startIndex, offsetBy: self.editedPassword.count)
-                    self.editedPassword = "\(self.editedPassword)\(val.suffix(from: index))"
+                    self.editedPassword += val.suffix(from: index)
                     
                 } else {
                     

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -194,10 +194,6 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
                 }
                 
                 if let revealObserver = cellConfiguration.revealPasswordObserver {
-                    // Commented this out because font does not conform with the rest of the app
-                    // Uncomment this line out of this was intentional
-//                    cell.textValue.font = UIFont(name: "Menlo-Regular", size: 16)
-                    
                     cell.revealButton.rx.tap
                         .map { _ -> Bool in
                             cell.revealButton.isSelected = !cell.revealButton.isSelected

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -194,7 +194,9 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
                 }
                 
                 if let revealObserver = cellConfiguration.revealPasswordObserver {
-                    cell.textValue.font = UIFont(name: "Menlo-Regular", size: 16)
+                    // Commented this out because font does not conform with the rest of the app
+                    // Uncomment this line out of this was intentional
+//                    cell.textValue.font = UIFont(name: "Menlo-Regular", size: 16)
                     
                     cell.revealButton.rx.tap
                         .map { _ -> Bool in


### PR DESCRIPTION
Fixes #1152 #1156 #1172 #1233

This PR fixes all of the following issue related to Discard, Save, and Reveal password in Edit mode. Without this PR, there are 4 major issues that I noticed (some were already reported):

1. Discard does not revert text back to the original string in the username and password fields. Before this PR, the user had to physically click out of the page and open it again to see the discarded changes.
2. When Save is clicked by the user, the Hide/Reveal password function does not update the password value to the updated string. The user has to exit and re-enter the page to see the changes to the password.
3. The password field saves the "•" values when a password is hidden and 'Save' has been clicked. 
4. There is no error handling for empty fields when saving a username or password. 

This PR fixes all the above issues that I noticed related to Edit mode. Below are screen shots of the error handling (with error handling, I also included haptic feedback).

## Screenshot

![Simulator Screen Shot - iPhone 11 - 2020-05-23 at 22 29 45](https://user-images.githubusercontent.com/35638500/82745442-fbbf1980-9d49-11ea-8094-5a97201d1295.png)

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests (UI specs)
- consider running this branch in the simulator and check for warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
