### PR TITLE
Set ITSAppUsesNonExemptEncryption to NO in the Info.plist

### DIFF
--- a/lockbox-ios/Common/Resources/Info.plist
+++ b/lockbox-ios/Common/Resources/Info.plist
@@ -76,6 +76,8 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>


### PR DESCRIPTION
This patch sets `ITSAppUsesNonExemptEncryption` to `false` so that we don't have to go through those questions every time when a new build is submitted to App Store Connect.